### PR TITLE
GEA-1092: Go sdk docs autogen script

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,28 @@ Future support is incoming.
 
 To install our linters, simply run `./dev/setup_repo.sh`
 These linters will run on every `git commit` operation.
+
+# Generate SDK Documentation
+
+## Overview
+
+Throughout the SDK, there are go doc strings that serve as the source of our SDK docs.
+
+The documentation pipeline here looks like:
+
+1. Write doc strings throughout your go code. Please refer to existing doc strings as an example of what and how to document.
+1. Make your pull request.
+1. After the pull request is merged, go ahead and run the `autogen_docs.go` script to generate the JSON docs uses for rendering.
+1. Copy the output from `autogen_docs.go` and overwrite the existing go_sdk.json file in the docs repo. File is located in platform/docs/sdk/go_sdk.json in the Pangea monorepo. Save this and make a merge request to update the Golang SDK docs in the Pangea monorepo.
+
+## Running the autogen sdk doc script
+
+From the root of the `go-pangea` repo run:
+```sh
+go run dev/autogen_docs.go
+```
+That will output the script in the terminal. If you're on a mac, you can do
+```sh
+go run dev/autogen_docs.go | pbcopy
+```
+to copy the output from the script into your clipboard.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,42 @@ Future support is incoming.
 To install our linters, simply run `./dev/setup_repo.sh`
 These linters will run on every `git commit` operation.
 
+# Writing Docs
+
+To maintain parity with documentation across all our SDKs, please follow this format when writing a doc comment for a *published* function or method. Published means the function ro method is listed as an endpoint in our API Reference docs.
+
+Published Doc Example:
+```
+// Redact
+//
+// Redacts the content of a single text string.
+//
+// Example:
+//
+//  input := &redact.TextInput{
+//  	Text: pangea.String("my phone number is 123-456-7890"),
+//  }
+//
+//  redactOutput, _, err := redactcli.Redact(ctx, input)
+//
+```
+
+Example breakdown:
+```
+// Redact <-- Displayed as the Summary/Heading field in docs
+//
+// Redacts the content of a single text string. <-- Displayed as the Description field in docs
+//
+// Example: <-- All lines below this are used as the code snippet field in docs
+//
+//  input := &redact.TextInput{
+//  	Text: pangea.String("my phone number is 123-456-7890"),
+//  }
+//
+//  redactOutput, _, err := redactcli.Redact(ctx, input)
+//
+```
+
 # Generate SDK Documentation
 
 ## Overview
@@ -70,17 +106,17 @@ The documentation pipeline here looks like:
 
 1. Write doc strings throughout your go code. Please refer to existing doc strings as an example of what and how to document.
 1. Make your pull request.
-1. After the pull request is merged, go ahead and run the `autogen_docs.go` script to generate the JSON docs uses for rendering.
-1. Copy the output from `autogen_docs.go` and overwrite the existing go_sdk.json file in the docs repo. File is located in platform/docs/sdk/go_sdk.json in the Pangea monorepo. Save this and make a merge request to update the Golang SDK docs in the Pangea monorepo.
+1. After the pull request is merged, go ahead and run the autogen docs script to generate the JSON docs uses for rendering.
+1. Copy the output from autogen docs and overwrite the existing go_sdk.json file in the docs repo. File is located in platform/docs/sdk/go_sdk.json in the Pangea monorepo. Save this and make a merge request to update the Golang SDK docs in the Pangea monorepo.
 
 ## Running the autogen sdk doc script
 
 From the root of the `go-pangea` repo run:
 ```sh
-go run dev/autogen_docs.go
+go run dev/autogendoc/main.go
 ```
 That will output the script in the terminal. If you're on a mac, you can do
 ```sh
-go run dev/autogen_docs.go | pbcopy
+go run dev/autogendoc/main.go | pbcopy
 ```
 to copy the output from the script into your clipboard.

--- a/dev/autogen_docs.go
+++ b/dev/autogen_docs.go
@@ -147,7 +147,7 @@ type DocumentedType struct {
 type DocumentedFunc struct {
 	Name        string       `json:"name"`
 	Doc         string       `json:"doc"`
-	Declaration string       `json:"Declaration"`
+	Declaration string       `json:"declaration"`
 	Level       int          `json:"level"`
 	Type        *AstFuncType `json:"type"`
 }
@@ -155,7 +155,7 @@ type DocumentedFunc struct {
 type DocumentedValue struct {
 	Doc     string   `json:"doc"`
 	Names   []string `json:"names"`
-	Comment string   `json:"comment",omitempty`
+	Comment string   `json:"comment"`
 }
 
 type DocumentedConst struct {

--- a/dev/autogen_docs.go
+++ b/dev/autogen_docs.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/token"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	// Make sure we're at the root of the go-pangea sdk repo
+	if _, err := os.Stat("./service"); os.IsNotExist(err) {
+		fmt.Println("::::::::::::::::::::::::::::::::::::::::::::::::::::::::")
+		fmt.Println(": ERROR                                                :")
+		fmt.Println(": run this script from the root of the go-pangea repo  :")
+		fmt.Println("::::::::::::::::::::::::::::::::::::::::::::::::::::::::")
+		log.Fatal(err)
+	}
+
+	fs, err := filepath.Glob("./service/**/*.go")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create the AST
+	fset := token.NewFileSet()
+	files := []*ast.File{}
+
+	for _, file := range fs {
+		parsedFile := mustParse(fset, file)
+		files = append(files, parsedFile)
+	}
+
+	// Compute package documentation with examples.
+	p, err := doc.NewFromFiles(fset, files, "")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	resultJson, err := json.Marshal(Package{
+		Doc:        p.Doc,
+		Name:       p.Name,
+		ImportPath: p.ImportPath,
+		Imports:    p.Imports,
+		Filenames:  p.Filenames,
+		// Notes:      &p.Notes,
+
+		// Consts: &p.Consts,
+		// Types:  &p.Types,
+		// Vars:   &p.Vars,
+		// Funcs:  &p.Funcs,
+	})
+
+	fmt.Println(string(resultJson))
+
+	// fmt.Printf("package %s - %s", p.Name, p.Doc)
+	// fmt.Printf("func %s - %s", p.Funcs[0].Name, p.Funcs[0].Doc)
+	// fmt.Println("TYPES::::::::::")
+	// // fmt.Println(len(p.Types))
+	// for i := 0; i < len(p.Types); i++ {
+	// 	fmt.Println(p.Types[i].Name, p.Types[i].Methods)
+
+	// 	for k := range p.Types[i].Methods {
+	// 		method := p.Types[i].Methods[k]
+
+	// 		fmt.Println(method.Name, method.Doc)
+	// 	}
+	// }
+	// fmt.Println("Funcs::::::::::")
+	// fmt.Println(len(p.Funcs))
+	// for i := range p.Funcs {
+	// 	f := p.Funcs[i]
+	// 	fmt.Println(f.Name, f.Doc)
+	// }
+
+	// fmt.Printf(" ⤷ example with suffix %q - %s", p.Funcs[0].Examples[0].Suffix, p.Funcs[0].Examples[0].Doc)
+
+}
+
+func mustParse(fset *token.FileSet, filename string) *ast.File {
+	f, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return f
+}
+
+type Package struct {
+	Doc        string             `json:"doc"`
+	Name       string             `json:"name"`
+	ImportPath string             `json:"importPath"`
+	Imports    []string           `json:"imports"`
+	Filenames  []string           `json:"filenames"`
+	Notes      map[string][]*Note `json:"notes"`
+
+	// declarations
+	Consts []*Value `json:"consts"`
+	Types  []*Type  `json:"types"`
+	Vars   []*Value `json:"vars"`
+	Funcs  []*Func  `json:"funcs"`
+
+	// Examples is a sorted list of examples associated with
+	// the package. Examples are extracted from _test.go files
+	// provided to NewFromFiles.
+	Examples []*Example `json:"examples"`
+}
+
+type Func struct {
+	Doc  string        `json:"doc"`
+	Name string        `json:"name"`
+	Decl *ast.FuncDecl `json:"decl"`
+
+	// methods
+	// (for functions, these fields have the respective zero value)
+	Recv  string `json:"recv"`  // actual   receiver "T" or "*T"
+	Orig  string `json:"orig"`  // original receiver "T" or "*T"
+	Level int    `json:"level"` // embedding level; 0 means not embedded
+
+	// Examples is a sorted list of examples associated with this
+	// function or method. Examples are extracted from _test.go files
+	// provided to NewFromFiles.
+	Examples []*Example `json:"examples"`
+}
+
+type Type struct {
+	Doc  string       `json:"doc"`
+	Name string       `json:"name"`
+	Decl *ast.GenDecl `json:"decl"`
+
+	// associated declarations
+	Consts  []*Value `json:"consts"`  // sorted list of constants of (mostly) this type
+	Vars    []*Value `json:"vars"`    // sorted list of variables of (mostly) this type
+	Funcs   []*Func  `json:"funcs"`   // sorted list of functions returning this type
+	Methods []*Func  `json:"methods"` // sorted list of methods (including embedded ones) of this type
+
+	// Examples is a sorted list of examples associated with
+	// this type. Examples are extracted from _test.go files
+	// provided to NewFromFiles.
+	Examples []*Example `json:"examples"`
+}
+
+type Example struct {
+	Name        string              `json:"name"`   // name of the item being exemplified (including optional suffix)
+	Suffix      string              `json:"suffix"` // example suffix, without leading '_' (only populated by NewFromFiles)
+	Doc         string              `json:"doc"`    // example function doc string
+	Code        ast.Node            `json:"code"`
+	Play        *ast.File           `json:"play"` // a whole program version of the example
+	Comments    []*ast.CommentGroup `json:"comments"`
+	Output      string              `json:output""` // expected output
+	Unordered   bool                `json:"unordered"`
+	EmptyOutput bool                `json:"emptyoutput"` // expect empty output
+	Order       int                 `json:"order"`       // original source code order
+}
+
+type Value struct {
+	Doc   string       `json:"doc"`
+	Names []string     `json:"names"` // var or const names in declaration order
+	Decl  *ast.GenDecl `json:"decl"`
+	// contains filtered or unexported fields
+}
+
+type Note struct {
+	Pos, End token.Pos `json:"Pos"`  // position range of the comment containing the marker
+	UID      string    `json:"UID"`  // uid found with the marker
+	Body     string    `json:"Body"` // note body text
+}

--- a/dev/autogen_docs.go
+++ b/dev/autogen_docs.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"go/ast"
 	"go/doc"
 	"go/parser"
+	"go/printer"
 	"go/token"
 	"log"
 	"os"
@@ -56,12 +58,11 @@ func main() {
 	// 	log.Fatal(err)
 	// }
 
-	// type pkgMap struct {
-	// 	fileSet *token.FileSet
-	// 	docPkg  *doc.Package
-	// }
-	// packages := make(map[string]pkgMap)
-	packages := []*doc.Package{}
+	type pkgMap struct {
+		fileSet *token.FileSet
+		docPkg  *doc.Package
+	}
+	packages := make(map[string]pkgMap)
 
 	for _, dir := range serviceDirs {
 		// Create the AST
@@ -77,14 +78,8 @@ func main() {
 		// filepaths = append(filepaths, pangeaFiles...) // Maybe also add the go files in pangea/ ?
 
 		for _, file := range filepaths {
-			// fmt.Println("LOOKING AT: ", file)
 			astFile := mustParse(fset, file)
 			files = append(files, astFile)
-
-			// fmt.Println(":::::::: PACKAGE NAME:::::", astFile.Name.Name)
-			// for _, comment := range astFile.Comments {
-			// 	fmt.Println("COMMENT", comment.Text())
-			// }
 		}
 
 		// Compute package documentation with examples.
@@ -93,120 +88,29 @@ func main() {
 			log.Fatal(err)
 		}
 
-		fmt.Println("DOC package", p.Name, p.Filenames)
-		packages = append(packages, p)
-		// packages[p.Name] = pkgMap{
-		// 	fileSet: fset,
-		// 	docPkg:  p,
-		// }
+		packages[p.Name] = pkgMap{
+			fileSet: fset,
+			docPkg:  p,
+		}
 	}
 
+	documents := []*Document{}
 	for _, p := range packages {
-		fmt.Println("PACKAGE:::::", p.Name)
+		types := gatherTypes(p.docPkg.Types, p.fileSet)
+		funcs := gatherFuncs(p.docPkg.Funcs, p.fileSet)
 
-		types := gatherTypes(p.Types)
-		funcs := gatherFuncs(p.Funcs)
-
-		resultJson, err := json.MarshalIndent(Document{
-			Package: p.Name,
+		documents = append(documents, &Document{
+			Package: p.docPkg.Name,
 			Types:   types,
 			Funcs:   funcs,
-		}, "", "\t")
-		if err != nil {
-			log.Fatal(err)
-		}
-		fmt.Println(string(resultJson))
-
-		// for _, types := range p.Types {
-		// 	fmt.Println("  type: ", types.Name)
-		// 	fmt.Println("    > decl: ", &types.Decl)
-
-		// 	// ast.Inspect(types.Decl, func(node ast.Node) bool {
-		// 	// 	switch n := node.(type) {
-		// 	// 	case nil:
-		// 	// 		return true
-		// 	// 	case *ast.FuncDecl:
-		// 	// 		name := n.Name.Name
-		// 	// 		recv :=
-
-		// 	// 	}
-		// 	// 	// find funcs
-		// 	// 	fn, ok := n.(*ast.FuncType)
-		// 	// 	if ok {
-		// 	// 		fmt.Printf("fn: %v\n", fn)
-		// 	// 		if fn.Params != nil {
-		// 	// 			for _, field := range fn.Params.List {
-		// 	// 				fmt.Println("HEREEEE", field.Names)
-		// 	// 			}
-		// 	// 		}
-		// 	// 		// fmt.Printf("func found on line %d:\n\t", fset.Position())
-		// 	// 	}
-
-		// 	// 	return true
-		// 	// })
-
-		// 	// for _, c := range types.Consts {
-		// 	// 	fmt.Println("    > consts", c)
-		// 	// }
-		// 	// for _, v := range types.Vars {
-		// 	// 	fmt.Println("    > vars", v.Names[0])
-		// 	// }
-		// 	// // fmt.Println("    > decl.specs", types.Decl.Specs)
-
-		// 	// for _, methods := range types.Methods {
-		// 	// 	fmt.Println("    methods: ")
-		// 	// 	fmt.Println("      > name:", methods.Name)
-		// 	// 	fmt.Println("      > doc:", methods.Doc)
-		// 	// 	fmt.Println("      > examples:", methods.Examples)
-
-		// 	// 	for _, params := range methods.Decl.Type.Params.List {
-		// 	// 		fmt.Println("      > params:", params.Names[0], params.Type.Pos(), params.Type.End())
-		// 	// 	}
-		// 	// }
-
-		// 	// for _, funcs := range types.Funcs {
-		// 	// 	fmt.Println("    funcs: ", funcs.Name, funcs.Doc)
-		// 	// }
-		// }
-
-		// for _, funcs := range p.Funcs {
-		// 	fmt.Println("    funcs: ", funcs.Name, funcs.Doc)
-		// }
+		})
 	}
 
-	// b, err := pangeautil.CanonicalizeJSONMarshall(
-	// 	Package{
-	// 		Doc: p.Doc,
-	// 		Name: p.Name,
-	// 		Types: p.Types,
-	// 	},
-	// )
-
-	// fmt.Println(("result json:::::::"))
-	// fmt.Println(string(resultJson))
-
-	// fmt.Printf("package %s - %s", p.Name, p.Doc)
-	// fmt.Printf("func %s - %s", p.Funcs[0].Name, p.Funcs[0].Doc)
-	// fmt.Println("TYPES::::::::::")
-	// // fmt.Println(len(p.Types))
-	// for i := 0; i < len(p.Types); i++ {
-	// 	fmt.Println(p.Types[i].Name, p.Types[i].Methods)
-
-	// 	for k := range p.Types[i].Methods {
-	// 		method := p.Types[i].Methods[k]
-
-	// 		fmt.Println(method.Name, method.Doc)
-	// 	}
-	// }
-	// fmt.Println("Funcs::::::::::")
-	// fmt.Println(len(p.Funcs))
-	// for i := range p.Funcs {
-	// 	f := p.Funcs[i]
-	// 	fmt.Println(f.Name, f.Doc)
-	// }
-
-	// fmt.Printf(" ⤷ example with suffix %q - %s", p.Funcs[0].Examples[0].Suffix, p.Funcs[0].Examples[0].Doc)
-
+	resultJson, err := json.MarshalIndent(documents, "", "\t")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf(string(resultJson))
 }
 
 func mustParse(fset *token.FileSet, filename string) *ast.File {
@@ -227,29 +131,31 @@ type Document struct {
 }
 
 type DocumentedType struct {
-	Name string `json:"name"`
-	Doc  string `json:"doc"`
+	Name        string `json:"name"`
+	Doc         string `json:"doc"`
+	Declaration string `json:"declaration"`
 
 	Funcs   []*DocumentedFunc `json:"funcs"`
 	Methods []*DocumentedFunc `json:"methods"`
 
 	Consts []*DocumentedValue `json:"consts"`
 	Vars   []*DocumentedValue `json:"vars"`
+
+	AstFields []*AstField `json:"astFields"`
 }
 
 type DocumentedFunc struct {
-	Name          string       `json:"name"`
-	Doc           string       `json:"doc"`
-	Recv          string       `json:"recv"`
-	FormattedRecv string       `json:"formattedRecv"`
-	Orig          string       `json:"orig"`
-	Level         int          `json:"level"`
-	Type          *AstFuncType `json:"type"`
+	Name        string       `json:"name"`
+	Doc         string       `json:"doc"`
+	Declaration string       `json:"Declaration"`
+	Level       int          `json:"level"`
+	Type        *AstFuncType `json:"type"`
 }
 
 type DocumentedValue struct {
-	Doc   string   `json:"doc"`
-	Names []string `json:"names"`
+	Doc     string   `json:"doc"`
+	Names   []string `json:"names"`
+	Comment string   `json:"comment",omitempty`
 }
 
 type DocumentedConst struct {
@@ -257,16 +163,31 @@ type DocumentedConst struct {
 	Doc  string `json:"doc"`
 }
 
-func gatherTypes(docTypes []*doc.Type) []*DocumentedType {
+func gatherTypes(docTypes []*doc.Type, fs *token.FileSet) []*DocumentedType {
 	types := []*DocumentedType{}
 	for _, t := range docTypes {
+
+		vals := []*AstField{}
+		ast.Inspect(t.Decl, func(n ast.Node) bool {
+			switch x := n.(type) {
+			case *ast.Field:
+				field := gatherAstField(x, fs)
+				if field != nil {
+					vals = append(vals, field)
+				}
+			}
+			return true
+		})
+
 		types = append(types, &DocumentedType{
-			Name:    t.Name,
-			Doc:     t.Doc,
-			Funcs:   gatherFuncs(t.Funcs),
-			Methods: gatherFuncs(t.Methods),
-			Vars:    gatherValues(t.Vars),
-			Consts:  gatherValues(t.Consts),
+			Name:        t.Name,
+			Doc:         t.Doc,
+			Declaration: prettify(t.Decl, fs),
+			Funcs:       gatherFuncs(t.Funcs, fs),
+			Methods:     gatherFuncs(t.Methods, fs),
+			Vars:        gatherValues(t.Vars),
+			Consts:      gatherValues(t.Consts),
+			AstFields:   vals,
 		})
 	}
 
@@ -286,35 +207,20 @@ func gatherValues(vals []*doc.Value) []*DocumentedValue {
 	return values
 }
 
-func gatherFuncs(docFuncs []*doc.Func) []*DocumentedFunc {
+func gatherFuncs(docFuncs []*doc.Func, fs *token.FileSet) []*DocumentedFunc {
 	funcs := []*DocumentedFunc{}
 
 	for _, f := range docFuncs {
-
-		var formattedRecv = ""
-		if len(f.Recv) > 0 {
-			formattedRecv = "(" + f.Recv + ")"
-		}
-
 		funcs = append(funcs, &DocumentedFunc{
-			Name:          f.Name,
-			Doc:           f.Doc,
-			Recv:          f.Recv,
-			FormattedRecv: formattedRecv,
-			Orig:          f.Orig,
-			Level:         f.Level,
-			Type:          gatherAstFuncType(f.Decl.Type),
+			Name:        f.Name,
+			Doc:         f.Doc,
+			Declaration: prettify(f.Decl, fs),
+			Level:       f.Level,
+			Type:        gatherAstFuncType(f.Decl.Type, fs),
 		})
 	}
 
 	return funcs
-}
-
-func gatherAstFuncType(astType *ast.FuncType) *AstFuncType {
-	return &AstFuncType{
-		Params:  gatherAstFieldList(astType.Params.List),
-		Results: gatherAstFieldList(astType.Results.List),
-	}
 }
 
 type AstFuncType struct {
@@ -324,117 +230,57 @@ type AstFuncType struct {
 }
 
 type AstField struct {
-	Doc        string   `json:"doc"`
-	Comment    string   `json:"comment"`
-	Names      []string `json:"names"`
-	IsExported bool     `json:"isExported"`
+	Doc     string   `json:"doc"`
+	Comment string   `json:"comment"`
+	Names   []string `json:"names"`
+	Type    string   `json:"type"`
+	Tag     string   `json:"tag"`
 }
 
-func gatherAstFieldList(l []*ast.Field) []*AstField {
+func gatherAstFuncType(astType *ast.FuncType, fs *token.FileSet) *AstFuncType {
+	return &AstFuncType{
+		Params:  gatherAstFieldList(astType.Params.List, fs),
+		Results: gatherAstFieldList(astType.Results.List, fs),
+	}
+}
+
+func gatherAstField(f *ast.Field, fs *token.FileSet) *AstField {
+	names := []string{}
+	for _, fns := range f.Names {
+		names = append(names, fns.Name)
+	}
+
+	if len(names) == 0 && f.Doc.Text() == "" {
+		return nil
+	}
+
+	var tag string
+	if f.Tag != nil {
+		tag = f.Tag.Value
+	}
+
+	return &AstField{
+		Doc:     f.Doc.Text(),
+		Comment: f.Comment.Text(),
+		Names:   names,
+		Type:    prettify(f.Type, fs),
+		Tag:     tag,
+	}
+}
+
+func gatherAstFieldList(fl []*ast.Field, fs *token.FileSet) []*AstField {
 	fields := []*AstField{}
-	for _, field := range l {
-		names := []string{}
-
-		for _, fn := range field.Names {
-			names = append(names, fn.Obj.Name)
-		}
-
-		fields = append(fields, &AstField{
-			Doc:     field.Doc.Text(),
-			Comment: field.Comment.Text(),
-			Names:   names,
-		})
+	for _, field := range fl {
+		fields = append(fields, gatherAstField(field, fs))
 	}
 
 	return fields
 }
 
-// Custom marshal func from
-// https://blog.logrocket.com/using-json-go-guide/
-// func (p *doc.Package) MarshalJSON() ([]byte, error) {
-// 	type PackageAlias doc.Package
-// 	return json.Marshal(&struct{
-// 		*PackageAlias
+// Pretty print the ast Node as a string
+func prettify(node interface{}, fs *token.FileSet) string {
+	var stringBuffer bytes.Buffer
+	printer.Fprint(&stringBuffer, fs, node)
 
-// 	})
-// }
-
-// type Package struct {
-// 	Doc        string            `json:"doc"`
-// 	Name       string            `json:"name"`
-// 	ImportPath string            `json:"importPath"`
-// 	Imports    []string          `json:"imports"`
-// 	Filenames  []string          `json:"filenames"`
-// 	Notes      map[string][]Note `json:"notes"`
-
-// 	// declarations
-// 	Consts []Value `json:"consts"`
-// 	Types  []Type  `json:"types"`
-// 	Vars   []Value `json:"vars"`
-// 	Funcs  []Func  `json:"funcs"`
-
-// 	// Examples is a sorted list of examples associated with
-// 	// the package. Examples are extracted from _test.go files
-// 	// provided to NewFromFiles.
-// 	Examples []Example `json:"examples"`
-// }
-
-// type Func struct {
-// 	Doc  string        `json:"doc"`
-// 	Name string        `json:"name"`
-// 	Decl *ast.FuncDecl `json:"decl"`
-
-// 	// methods
-// 	// (for functions, these fields have the respective zero value)
-// 	Recv  string `json:"recv"`  // actual   receiver "T" or "*T"
-// 	Orig  string `json:"orig"`  // original receiver "T" or "*T"
-// 	Level int    `json:"level"` // embedding level; 0 means not embedded
-
-// 	// Examples is a sorted list of examples associated with this
-// 	// function or method. Examples are extracted from _test.go files
-// 	// provided to NewFromFiles.
-// 	Examples []*Example `json:"examples"`
-// }
-
-// type Type struct {
-// 	Doc  string       `json:"doc"`
-// 	Name string       `json:"name"`
-// 	Decl *ast.GenDecl `json:"decl"`
-
-// 	// associated declarations
-// 	Consts  []*Value `json:"consts"`  // sorted list of constants of (mostly) this type
-// 	Vars    []*Value `json:"vars"`    // sorted list of variables of (mostly) this type
-// 	Funcs   []*Func  `json:"funcs"`   // sorted list of functions returning this type
-// 	Methods []*Func  `json:"methods"` // sorted list of methods (including embedded ones) of this type
-
-// 	// Examples is a sorted list of examples associated with
-// 	// this type. Examples are extracted from _test.go files
-// 	// provided to NewFromFiles.
-// 	Examples []*Example `json:"examples"`
-// }
-
-// type Example struct {
-// 	Name        string              `json:"name"`   // name of the item being exemplified (including optional suffix)
-// 	Suffix      string              `json:"suffix"` // example suffix, without leading '_' (only populated by NewFromFiles)
-// 	Doc         string              `json:"doc"`    // example function doc string
-// 	Code        ast.Node            `json:"code"`
-// 	Play        *ast.File           `json:"play"` // a whole program version of the example
-// 	Comments    []*ast.CommentGroup `json:"comments"`
-// 	Output      string              `json:output""` // expected output
-// 	Unordered   bool                `json:"unordered"`
-// 	EmptyOutput bool                `json:"emptyoutput"` // expect empty output
-// 	Order       int                 `json:"order"`       // original source code order
-// }
-
-// type Value struct {
-// 	Doc   string       `json:"doc"`
-// 	Names []string     `json:"names"` // var or const names in declaration order
-// 	Decl  *ast.GenDecl `json:"decl"`
-// 	// contains filtered or unexported fields
-// }
-
-// type Note struct {
-// 	Pos, End token.Pos `json:"Pos"`  // position range of the comment containing the marker
-// 	UID      string    `json:"UID"`  // uid found with the marker
-// 	Body     string    `json:"Body"` // note body text
-// }
+	return string(stringBuffer.Bytes())
+}

--- a/dev/autogen_docs.go
+++ b/dev/autogen_docs.go
@@ -13,50 +13,177 @@ import (
 )
 
 func main() {
+	DIRECTORIES := []string{
+		"./service",
+		"./pangea",
+		"./pangea/hash",
+	}
+
 	// Make sure we're at the root of the go-pangea sdk repo
-	if _, err := os.Stat("./service"); os.IsNotExist(err) {
-		fmt.Println("::::::::::::::::::::::::::::::::::::::::::::::::::::::::")
-		fmt.Println(": ERROR                                                :")
-		fmt.Println(": run this script from the root of the go-pangea repo  :")
-		fmt.Println("::::::::::::::::::::::::::::::::::::::::::::::::::::::::")
-		log.Fatal(err)
+	// and we can find the directories to pull docs from
+	for _, dir := range DIRECTORIES {
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			fmt.Println("::::::::::::::::::::::::::::::::::::::::::::::::::::::::")
+			fmt.Println(": ERROR")
+			fmt.Printf(": could not find directory: %s", dir)
+			fmt.Println(":")
+			fmt.Println(": make sure to run this script from")
+			fmt.Println(": the root of the go-pangea repo")
+			fmt.Println("::::::::::::::::::::::::::::::::::::::::::::::::::::::::")
+			log.Fatal(err)
+		}
 	}
 
-	fs, err := filepath.Glob("./service/**/*.go")
+	serviceDirs, err := filepath.Glob("./service/*")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// Create the AST
-	fset := token.NewFileSet()
-	files := []*ast.File{}
+	// Walk the dir for Pangea package: "./pangea"
+	// pangeaFiles := []string{}
+	// err = filepath.WalkDir("./pangea", func(path string, d fs.DirEntry, err error) error {
+	// 	if err != nil {
+	// 		return err
+	// 	}
 
-	for _, file := range fs {
-		parsedFile := mustParse(fset, file)
-		files = append(files, parsedFile)
+	// 	if !d.IsDir() {
+	// 		pangeaFiles = append(pangeaFiles, path)
+	// 	}
+
+	// 	return nil
+	// })
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+
+	// type pkgMap struct {
+	// 	fileSet *token.FileSet
+	// 	docPkg  *doc.Package
+	// }
+	// packages := make(map[string]pkgMap)
+	packages := []*doc.Package{}
+
+	for _, dir := range serviceDirs {
+		// Create the AST
+		fset := token.NewFileSet()
+		files := []*ast.File{}
+
+		serviceFiles, err := filepath.Glob(fmt.Sprintf("%s/*.go", dir))
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		filepaths := append([]string{}, serviceFiles...)
+		// filepaths = append(filepaths, pangeaFiles...) // Maybe also add the go files in pangea/ ?
+
+		for _, file := range filepaths {
+			// fmt.Println("LOOKING AT: ", file)
+			astFile := mustParse(fset, file)
+			files = append(files, astFile)
+
+			// fmt.Println(":::::::: PACKAGE NAME:::::", astFile.Name.Name)
+			// for _, comment := range astFile.Comments {
+			// 	fmt.Println("COMMENT", comment.Text())
+			// }
+		}
+
+		// Compute package documentation with examples.
+		p, err := doc.NewFromFiles(fset, files, fmt.Sprintf("github.com/pangeacyber/go-pangea/%s", dir), doc.AllMethods)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Println("DOC package", p.Name, p.Filenames)
+		packages = append(packages, p)
+		// packages[p.Name] = pkgMap{
+		// 	fileSet: fset,
+		// 	docPkg:  p,
+		// }
 	}
 
-	// Compute package documentation with examples.
-	p, err := doc.NewFromFiles(fset, files, "")
-	if err != nil {
-		log.Fatal(err)
+	for _, p := range packages {
+		fmt.Println("PACKAGE:::::", p.Name)
+
+		types := gatherTypes(p.Types)
+		funcs := gatherFuncs(p.Funcs)
+
+		resultJson, err := json.MarshalIndent(Document{
+			Package: p.Name,
+			Types:   types,
+			Funcs:   funcs,
+		}, "", "\t")
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(string(resultJson))
+
+		// for _, types := range p.Types {
+		// 	fmt.Println("  type: ", types.Name)
+		// 	fmt.Println("    > decl: ", &types.Decl)
+
+		// 	// ast.Inspect(types.Decl, func(node ast.Node) bool {
+		// 	// 	switch n := node.(type) {
+		// 	// 	case nil:
+		// 	// 		return true
+		// 	// 	case *ast.FuncDecl:
+		// 	// 		name := n.Name.Name
+		// 	// 		recv :=
+
+		// 	// 	}
+		// 	// 	// find funcs
+		// 	// 	fn, ok := n.(*ast.FuncType)
+		// 	// 	if ok {
+		// 	// 		fmt.Printf("fn: %v\n", fn)
+		// 	// 		if fn.Params != nil {
+		// 	// 			for _, field := range fn.Params.List {
+		// 	// 				fmt.Println("HEREEEE", field.Names)
+		// 	// 			}
+		// 	// 		}
+		// 	// 		// fmt.Printf("func found on line %d:\n\t", fset.Position())
+		// 	// 	}
+
+		// 	// 	return true
+		// 	// })
+
+		// 	// for _, c := range types.Consts {
+		// 	// 	fmt.Println("    > consts", c)
+		// 	// }
+		// 	// for _, v := range types.Vars {
+		// 	// 	fmt.Println("    > vars", v.Names[0])
+		// 	// }
+		// 	// // fmt.Println("    > decl.specs", types.Decl.Specs)
+
+		// 	// for _, methods := range types.Methods {
+		// 	// 	fmt.Println("    methods: ")
+		// 	// 	fmt.Println("      > name:", methods.Name)
+		// 	// 	fmt.Println("      > doc:", methods.Doc)
+		// 	// 	fmt.Println("      > examples:", methods.Examples)
+
+		// 	// 	for _, params := range methods.Decl.Type.Params.List {
+		// 	// 		fmt.Println("      > params:", params.Names[0], params.Type.Pos(), params.Type.End())
+		// 	// 	}
+		// 	// }
+
+		// 	// for _, funcs := range types.Funcs {
+		// 	// 	fmt.Println("    funcs: ", funcs.Name, funcs.Doc)
+		// 	// }
+		// }
+
+		// for _, funcs := range p.Funcs {
+		// 	fmt.Println("    funcs: ", funcs.Name, funcs.Doc)
+		// }
 	}
 
-	resultJson, err := json.Marshal(Package{
-		Doc:        p.Doc,
-		Name:       p.Name,
-		ImportPath: p.ImportPath,
-		Imports:    p.Imports,
-		Filenames:  p.Filenames,
-		// Notes:      &p.Notes,
+	// b, err := pangeautil.CanonicalizeJSONMarshall(
+	// 	Package{
+	// 		Doc: p.Doc,
+	// 		Name: p.Name,
+	// 		Types: p.Types,
+	// 	},
+	// )
 
-		// Consts: &p.Consts,
-		// Types:  &p.Types,
-		// Vars:   &p.Vars,
-		// Funcs:  &p.Funcs,
-	})
-
-	fmt.Println(string(resultJson))
+	// fmt.Println(("result json:::::::"))
+	// fmt.Println(string(resultJson))
 
 	// fmt.Printf("package %s - %s", p.Name, p.Doc)
 	// fmt.Printf("func %s - %s", p.Funcs[0].Name, p.Funcs[0].Doc)
@@ -90,82 +217,224 @@ func mustParse(fset *token.FileSet, filename string) *ast.File {
 	return f
 }
 
-type Package struct {
-	Doc        string             `json:"doc"`
-	Name       string             `json:"name"`
-	ImportPath string             `json:"importPath"`
-	Imports    []string           `json:"imports"`
-	Filenames  []string           `json:"filenames"`
-	Notes      map[string][]*Note `json:"notes"`
+type Document struct {
+	Package string `json:"package"`
+	Doc     string `json:"doc"`
 
-	// declarations
-	Consts []*Value `json:"consts"`
-	Types  []*Type  `json:"types"`
-	Vars   []*Value `json:"vars"`
-	Funcs  []*Func  `json:"funcs"`
-
-	// Examples is a sorted list of examples associated with
-	// the package. Examples are extracted from _test.go files
-	// provided to NewFromFiles.
-	Examples []*Example `json:"examples"`
+	Types  []*DocumentedType  `json:"types"`
+	Consts []*DocumentedConst `json:"consts"`
+	Funcs  []*DocumentedFunc  `json:"funcs"`
 }
 
-type Func struct {
-	Doc  string        `json:"doc"`
-	Name string        `json:"name"`
-	Decl *ast.FuncDecl `json:"decl"`
+type DocumentedType struct {
+	Name string `json:"name"`
+	Doc  string `json:"doc"`
 
-	// methods
-	// (for functions, these fields have the respective zero value)
-	Recv  string `json:"recv"`  // actual   receiver "T" or "*T"
-	Orig  string `json:"orig"`  // original receiver "T" or "*T"
-	Level int    `json:"level"` // embedding level; 0 means not embedded
+	Funcs   []*DocumentedFunc `json:"funcs"`
+	Methods []*DocumentedFunc `json:"methods"`
 
-	// Examples is a sorted list of examples associated with this
-	// function or method. Examples are extracted from _test.go files
-	// provided to NewFromFiles.
-	Examples []*Example `json:"examples"`
+	Consts []*DocumentedValue `json:"consts"`
+	Vars   []*DocumentedValue `json:"vars"`
 }
 
-type Type struct {
-	Doc  string       `json:"doc"`
-	Name string       `json:"name"`
-	Decl *ast.GenDecl `json:"decl"`
-
-	// associated declarations
-	Consts  []*Value `json:"consts"`  // sorted list of constants of (mostly) this type
-	Vars    []*Value `json:"vars"`    // sorted list of variables of (mostly) this type
-	Funcs   []*Func  `json:"funcs"`   // sorted list of functions returning this type
-	Methods []*Func  `json:"methods"` // sorted list of methods (including embedded ones) of this type
-
-	// Examples is a sorted list of examples associated with
-	// this type. Examples are extracted from _test.go files
-	// provided to NewFromFiles.
-	Examples []*Example `json:"examples"`
+type DocumentedFunc struct {
+	Name          string       `json:"name"`
+	Doc           string       `json:"doc"`
+	Recv          string       `json:"recv"`
+	FormattedRecv string       `json:"formattedRecv"`
+	Orig          string       `json:"orig"`
+	Level         int          `json:"level"`
+	Type          *AstFuncType `json:"type"`
 }
 
-type Example struct {
-	Name        string              `json:"name"`   // name of the item being exemplified (including optional suffix)
-	Suffix      string              `json:"suffix"` // example suffix, without leading '_' (only populated by NewFromFiles)
-	Doc         string              `json:"doc"`    // example function doc string
-	Code        ast.Node            `json:"code"`
-	Play        *ast.File           `json:"play"` // a whole program version of the example
-	Comments    []*ast.CommentGroup `json:"comments"`
-	Output      string              `json:output""` // expected output
-	Unordered   bool                `json:"unordered"`
-	EmptyOutput bool                `json:"emptyoutput"` // expect empty output
-	Order       int                 `json:"order"`       // original source code order
+type DocumentedValue struct {
+	Doc   string   `json:"doc"`
+	Names []string `json:"names"`
 }
 
-type Value struct {
-	Doc   string       `json:"doc"`
-	Names []string     `json:"names"` // var or const names in declaration order
-	Decl  *ast.GenDecl `json:"decl"`
-	// contains filtered or unexported fields
+type DocumentedConst struct {
+	Name string `json:"name"`
+	Doc  string `json:"doc"`
 }
 
-type Note struct {
-	Pos, End token.Pos `json:"Pos"`  // position range of the comment containing the marker
-	UID      string    `json:"UID"`  // uid found with the marker
-	Body     string    `json:"Body"` // note body text
+func gatherTypes(docTypes []*doc.Type) []*DocumentedType {
+	types := []*DocumentedType{}
+	for _, t := range docTypes {
+		types = append(types, &DocumentedType{
+			Name:    t.Name,
+			Doc:     t.Doc,
+			Funcs:   gatherFuncs(t.Funcs),
+			Methods: gatherFuncs(t.Methods),
+			Vars:    gatherValues(t.Vars),
+			Consts:  gatherValues(t.Consts),
+		})
+	}
+
+	return types
 }
+
+func gatherValues(vals []*doc.Value) []*DocumentedValue {
+	values := []*DocumentedValue{}
+
+	for _, v := range vals {
+		values = append(values, &DocumentedValue{
+			Doc:   v.Doc,
+			Names: v.Names,
+		})
+	}
+
+	return values
+}
+
+func gatherFuncs(docFuncs []*doc.Func) []*DocumentedFunc {
+	funcs := []*DocumentedFunc{}
+
+	for _, f := range docFuncs {
+
+		var formattedRecv = ""
+		if len(f.Recv) > 0 {
+			formattedRecv = "(" + f.Recv + ")"
+		}
+
+		funcs = append(funcs, &DocumentedFunc{
+			Name:          f.Name,
+			Doc:           f.Doc,
+			Recv:          f.Recv,
+			FormattedRecv: formattedRecv,
+			Orig:          f.Orig,
+			Level:         f.Level,
+			Type:          gatherAstFuncType(f.Decl.Type),
+		})
+	}
+
+	return funcs
+}
+
+func gatherAstFuncType(astType *ast.FuncType) *AstFuncType {
+	return &AstFuncType{
+		Params:  gatherAstFieldList(astType.Params.List),
+		Results: gatherAstFieldList(astType.Results.List),
+	}
+}
+
+type AstFuncType struct {
+	TypeParams []*AstField `json:"typeParams"`
+	Params     []*AstField `json:"params"`
+	Results    []*AstField `json:"results"`
+}
+
+type AstField struct {
+	Doc        string   `json:"doc"`
+	Comment    string   `json:"comment"`
+	Names      []string `json:"names"`
+	IsExported bool     `json:"isExported"`
+}
+
+func gatherAstFieldList(l []*ast.Field) []*AstField {
+	fields := []*AstField{}
+	for _, field := range l {
+		names := []string{}
+
+		for _, fn := range field.Names {
+			names = append(names, fn.Obj.Name)
+		}
+
+		fields = append(fields, &AstField{
+			Doc:     field.Doc.Text(),
+			Comment: field.Comment.Text(),
+			Names:   names,
+		})
+	}
+
+	return fields
+}
+
+// Custom marshal func from
+// https://blog.logrocket.com/using-json-go-guide/
+// func (p *doc.Package) MarshalJSON() ([]byte, error) {
+// 	type PackageAlias doc.Package
+// 	return json.Marshal(&struct{
+// 		*PackageAlias
+
+// 	})
+// }
+
+// type Package struct {
+// 	Doc        string            `json:"doc"`
+// 	Name       string            `json:"name"`
+// 	ImportPath string            `json:"importPath"`
+// 	Imports    []string          `json:"imports"`
+// 	Filenames  []string          `json:"filenames"`
+// 	Notes      map[string][]Note `json:"notes"`
+
+// 	// declarations
+// 	Consts []Value `json:"consts"`
+// 	Types  []Type  `json:"types"`
+// 	Vars   []Value `json:"vars"`
+// 	Funcs  []Func  `json:"funcs"`
+
+// 	// Examples is a sorted list of examples associated with
+// 	// the package. Examples are extracted from _test.go files
+// 	// provided to NewFromFiles.
+// 	Examples []Example `json:"examples"`
+// }
+
+// type Func struct {
+// 	Doc  string        `json:"doc"`
+// 	Name string        `json:"name"`
+// 	Decl *ast.FuncDecl `json:"decl"`
+
+// 	// methods
+// 	// (for functions, these fields have the respective zero value)
+// 	Recv  string `json:"recv"`  // actual   receiver "T" or "*T"
+// 	Orig  string `json:"orig"`  // original receiver "T" or "*T"
+// 	Level int    `json:"level"` // embedding level; 0 means not embedded
+
+// 	// Examples is a sorted list of examples associated with this
+// 	// function or method. Examples are extracted from _test.go files
+// 	// provided to NewFromFiles.
+// 	Examples []*Example `json:"examples"`
+// }
+
+// type Type struct {
+// 	Doc  string       `json:"doc"`
+// 	Name string       `json:"name"`
+// 	Decl *ast.GenDecl `json:"decl"`
+
+// 	// associated declarations
+// 	Consts  []*Value `json:"consts"`  // sorted list of constants of (mostly) this type
+// 	Vars    []*Value `json:"vars"`    // sorted list of variables of (mostly) this type
+// 	Funcs   []*Func  `json:"funcs"`   // sorted list of functions returning this type
+// 	Methods []*Func  `json:"methods"` // sorted list of methods (including embedded ones) of this type
+
+// 	// Examples is a sorted list of examples associated with
+// 	// this type. Examples are extracted from _test.go files
+// 	// provided to NewFromFiles.
+// 	Examples []*Example `json:"examples"`
+// }
+
+// type Example struct {
+// 	Name        string              `json:"name"`   // name of the item being exemplified (including optional suffix)
+// 	Suffix      string              `json:"suffix"` // example suffix, without leading '_' (only populated by NewFromFiles)
+// 	Doc         string              `json:"doc"`    // example function doc string
+// 	Code        ast.Node            `json:"code"`
+// 	Play        *ast.File           `json:"play"` // a whole program version of the example
+// 	Comments    []*ast.CommentGroup `json:"comments"`
+// 	Output      string              `json:output""` // expected output
+// 	Unordered   bool                `json:"unordered"`
+// 	EmptyOutput bool                `json:"emptyoutput"` // expect empty output
+// 	Order       int                 `json:"order"`       // original source code order
+// }
+
+// type Value struct {
+// 	Doc   string       `json:"doc"`
+// 	Names []string     `json:"names"` // var or const names in declaration order
+// 	Decl  *ast.GenDecl `json:"decl"`
+// 	// contains filtered or unexported fields
+// }
+
+// type Note struct {
+// 	Pos, End token.Pos `json:"Pos"`  // position range of the comment containing the marker
+// 	UID      string    `json:"UID"`  // uid found with the marker
+// 	Body     string    `json:"Body"` // note body text
+// }

--- a/service/audit/api.go
+++ b/service/audit/api.go
@@ -78,12 +78,12 @@ func (a *Audit) Search(ctx context.Context, input *SearchInput) (*SearchOutput, 
 }
 
 // SearchResults is used to page through results from a previous search.
-func (a *Audit) SearchResults(ctx context.Context, input *SeachResultInput) (*SeachResultOutput, *pangea.Response, error) {
+func (a *Audit) SearchResults(ctx context.Context, input *SearchResultInput) (*SearchResultOutput, *pangea.Response, error) {
 	req, err := a.Client.NewRequest("POST", "v1/results", input)
 	if err != nil {
 		return nil, nil, err
 	}
-	out := SeachResultOutput{}
+	out := SearchResultOutput{}
 	resp, err := a.Client.Do(ctx, req, &out)
 	if err != nil {
 		return nil, nil, err
@@ -129,7 +129,7 @@ func SearchAll(ctx context.Context, client Client, input *SearchInput) (*Root, E
 	events := make(Events, 0, *out.Count)
 	events = append(events, out.Events...)
 	for pangea.IntValue(out.Count) > len(events) {
-		s := SeachResultInput{
+		s := SearchResultInput{
 			ID:                     out.ID,
 			IncludeMembershipProof: input.IncludeMembershipProof,
 			IncludeHash:            input.IncludeHash,
@@ -486,7 +486,7 @@ func (r *Record) VerifySignature(verifier signer.Verifier) bool {
 	return verifier.Verify(b, sig)
 }
 
-type SeachResultInput struct {
+type SearchResultInput struct {
 	// A search results identifier returned by the search call
 	// ID is a required field
 	ID *string `json:"id"`
@@ -507,7 +507,7 @@ type SeachResultInput struct {
 	Offset *int `json:"offset,omitempty"`
 }
 
-type SeachResultOutput struct {
+type SearchResultOutput struct {
 	// The total number of results that were returned by the search.
 	// Count is always populated on a successful response.
 	Count *int `json:"count"`

--- a/service/audit/api.go
+++ b/service/audit/api.go
@@ -11,7 +11,21 @@ import (
 	"github.com/pangeacyber/go-pangea/pangea"
 )
 
-// Log creates a log entry in the Secure Audit Log.
+// Log an entry
+//
+// Create a log entry in the Secure Audit Log.
+//
+// Example:
+//
+//  input := &audit.LogInput{
+//  	Event: &audit.LogEventInput{
+//  		Message: pangea.String("some important message."),
+//  	},
+//  	ReturnHash: pangea.Bool(true),
+//  }
+//
+//  logOutput, _, err := auditcli.Log(ctx, input)
+//
 func (a *Audit) Log(ctx context.Context, input *LogInput) (*LogOutput, *pangea.Response, error) {
 	if a.SignLogs {
 		err := input.Event.Sign(a.Signer)
@@ -33,7 +47,19 @@ func (a *Audit) Log(ctx context.Context, input *LogInput) (*LogOutput, *pangea.R
 	return &out, resp, nil
 }
 
-// Search the Secure Audit Log
+// Search for events
+//
+// Search for events that match the provided search criteria.
+//
+// Example:
+//
+//  input := &audit.SearchInput{
+//  	Query:                  pangea.String("message:log-123"),
+//  	IncludeMembershipProof: pangea.Bool(true),
+//  }
+//
+//  searchOutput, _, err := auditcli.Search(ctx, input)
+//
 func (a *Audit) Search(ctx context.Context, input *SearchInput) (*SearchOutput, *pangea.Response, error) {
 	req, err := a.Client.NewRequest("POST", "v1/search", input)
 	if err != nil {
@@ -69,7 +95,18 @@ func (a *Audit) SearchResults(ctx context.Context, input *SeachResultInput) (*Se
 	return &out, resp, nil
 }
 
+// Retrieve tamperproof verification
+//
 // Root returns current root hash and consistency proof.
+//
+// Example:
+//
+//  input := &audit.RootInput{
+//  	TreeSize: pangea.Int(10),
+//  }
+//
+//  rootOutput, _, err := auditcli.Root(ctx, input)
+//
 func (a *Audit) Root(ctx context.Context, input *RootInput) (*RootOutput, *pangea.Response, error) {
 	req, err := a.Client.NewRequest("POST", "v1/root", input)
 	if err != nil {

--- a/service/audit/api_test.go
+++ b/service/audit/api_test.go
@@ -187,7 +187,7 @@ func TestSearchResults(t *testing.T) {
 	})
 
 	client, _ := audit.New(pangeatesting.TestConfig(url))
-	input := &audit.SeachResultInput{
+	input := &audit.SearchResultInput{
 		ID:                     pangea.String("some-id"),
 		IncludeMembershipProof: pangea.Bool(true),
 		Limit:                  pangea.Int(50),
@@ -197,7 +197,7 @@ func TestSearchResults(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	want := &audit.SeachResultOutput{
+	want := &audit.SearchResultOutput{
 		Count: pangea.Int(2),
 		Events: audit.Events{
 			{

--- a/service/audit/integration_test.go
+++ b/service/audit/integration_test.go
@@ -85,7 +85,7 @@ func Test_Integration_SearchResults(t *testing.T) {
 	assert.NotNil(t, searchOut)
 	assert.NotNil(t, searchOut.ID)
 
-	searchResultInput := &audit.SeachResultInput{
+	searchResultInput := &audit.SearchResultInput{
 		ID: searchOut.ID,
 	}
 	out, _, err := client.SearchResults(ctx, searchResultInput)

--- a/service/audit/service.go
+++ b/service/audit/service.go
@@ -11,7 +11,7 @@ import (
 type Client interface {
 	Log(context.Context, *LogInput) (*LogOutput, *pangea.Response, error)
 	Search(context.Context, *SearchInput) (*SearchOutput, *pangea.Response, error)
-	SearchResults(context.Context, *SeachResultInput) (*SeachResultOutput, *pangea.Response, error)
+	SearchResults(context.Context, *SearchResultInput) (*SearchResultOutput, *pangea.Response, error)
 	Root(context.Context, *RootInput) (*RootOutput, *pangea.Response, error)
 }
 

--- a/service/embargo/api.go
+++ b/service/embargo/api.go
@@ -6,6 +6,18 @@ import (
 	"github.com/pangeacyber/go-pangea/pangea"
 )
 
+// Check IP
+//
+// Check this IP against known sanction and trade embargo lists.
+//
+// Example:
+//
+//  input := &embargo.IPCheckInput{
+//  	IP: pangea.String("213.24.238.26"),
+//  }
+//
+//  checkOutput, _, err := embargocli.IPCheck(ctx, input)
+//
 func (e *Embargo) IPCheck(ctx context.Context, input *IPCheckInput) (*CheckOutput, *pangea.Response, error) {
 	req, err := e.Client.NewRequest("POST", "v1/ip/check", input)
 	if err != nil {
@@ -19,6 +31,18 @@ func (e *Embargo) IPCheck(ctx context.Context, input *IPCheckInput) (*CheckOutpu
 	return &out, resp, nil
 }
 
+// ISO Code Check
+//
+// Check this country against known sanction and trade embargo lists.
+//
+// Example:
+//
+//  input := &embargo.ISOCheckInput{
+//  	ISOCode: pangea.String("CU"),
+//  }
+//
+//  checkOutput, _, err := embargocli.ISOCheck(ctx, input)
+//
 func (e *Embargo) ISOCheck(ctx context.Context, input *ISOCheckInput) (*CheckOutput, *pangea.Response, error) {
 	req, err := e.Client.NewRequest("POST", "v1/iso/check", input)
 	if err != nil {
@@ -33,10 +57,13 @@ func (e *Embargo) ISOCheck(ctx context.Context, input *ISOCheckInput) (*CheckOut
 }
 
 type IPCheckInput struct {
+	// Check this IP against the enabled embargo lists.
+	// Accepts both IPV4 and IPV6 strings.
 	IP *string `json:"ip,omitempty"`
 }
 
 type ISOCheckInput struct {
+	// Check this two character country ISO-code against the enabled embargo lists.
 	ISOCode *string `json:"iso_code,omitempty"`
 }
 

--- a/service/redact/api.go
+++ b/service/redact/api.go
@@ -7,7 +7,18 @@ import (
 	"github.com/pangeacyber/go-pangea/pangea"
 )
 
-// Redact sensitive information from provided text.
+// Redact
+//
+// Redacts the content of a single text string.
+//
+// Example:
+//
+//  input := &redact.TextInput{
+//  	Text: pangea.String("my phone number is 123-456-7890"),
+//  }
+//
+//  redactOutput, _, err := redactcli.Redact(ctx, input)
+//
 func (r *Redact) Redact(ctx context.Context, input *TextInput) (*TextOutput, *pangea.Response, error) {
 	req, err := r.Client.NewRequest("POST", "v1/redact", input)
 	if err != nil {
@@ -22,7 +33,28 @@ func (r *Redact) Redact(ctx context.Context, input *TextInput) (*TextOutput, *pa
 	return &out, resp, nil
 }
 
-// RedactStructured redacts sensitive infromation from structured data (e.g., JSON).
+// Redact structured
+//
+// Redacts text within a structured object.
+//
+// Example:
+//
+//  type yourCustomDataStruct struct {
+//  	Secret string `json:"secret"`
+//  }
+//
+//  input := &redact.StructuredInput{
+//  	JSONP: []*string{
+//  		pangea.String("$.secret"),
+//  	},
+//  }
+//  rawData := yourCustomDataStruct{
+//  	Secret: "My social security number is 0303456",
+//  }
+//  input.SetData(rawData)
+//
+//  redactOutput, _, err := redactcli.RedactStructured(ctx, input)
+//
 func (r *Redact) RedactStructured(ctx context.Context, input *StructuredInput) (*StructuredOutput, *pangea.Response, error) {
 	if input == nil {
 		input = &StructuredInput{}


### PR DESCRIPTION
This MR adds a script in `dev/autogen_docs.go` to pull all the doc strings from our Go SDK and output them into a JSON format the docs site could use to render SDK documentation.