### PR TITLE
Fix GEA 1295

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,8 @@ func main() {
 
 	embargocli, err := embargo.New(&pangea.Config{
 		Token: token,
-		EndpointConfig: &pangea.EndpointConfig{
-			Scheme: "https",
-			CSP:    "aws",
-		},
+		Domain: "dev.pangea.cloud/",
+		Insecure: false,
 		CfgToken: configID,
 	})
 	if err != nil {

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ func main() {
 	}
 
 	embargocli, err := embargo.New(&pangea.Config{
-		Token: token,
-		Domain: "dev.pangea.cloud/",
-		Insecure: false,
-		CfgToken: configID,
+		Token: 		token,
+		Domain: 	os.Getenv("PANGEA_DOMAIN"),
+		Insecure: 	false,
+		CfgToken: 	configID,
 	})
 	if err != nil {
 		log.Fatal("failed to create embargo client")

--- a/example/audit/log/main.go
+++ b/example/audit/log/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	auditcli, err := audit.New(&pangea.Config{
 		Token:    token,
-		Domain:   "dev.pangea.cloud/",
+		Domain:   os.Getenv("PANGEA_DOMAIN"),
 		Insecure: false,
 		CfgToken: configID,
 	})

--- a/example/audit/log/main.go
+++ b/example/audit/log/main.go
@@ -22,11 +22,9 @@ func main() {
 	}
 
 	auditcli, err := audit.New(&pangea.Config{
-		Token: token,
-		EndpointConfig: &pangea.EndpointConfig{
-			Scheme: "https",
-			CSP:    "aws",
-		},
+		Token:    token,
+		Domain:   "dev.pangea.cloud/",
+		Insecure: false,
 		CfgToken: configID,
 	})
 	if err != nil {

--- a/example/audit/results/main.go
+++ b/example/audit/results/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	auditcli, err := audit.New(&pangea.Config{
 		Token:    token,
-		Domain:   "dev.pangea.cloud/",
+		Domain:   os.Getenv("PANGEA_DOMAIN"),
 		Insecure: false,
 		CfgToken: configID,
 	})

--- a/example/audit/results/main.go
+++ b/example/audit/results/main.go
@@ -22,11 +22,9 @@ func main() {
 	}
 
 	auditcli, err := audit.New(&pangea.Config{
-		Token: token,
-		EndpointConfig: &pangea.EndpointConfig{
-			Scheme: "https",
-			CSP:    "aws",
-		},
+		Token:    token,
+		Domain:   "dev.pangea.cloud/",
+		Insecure: false,
 		CfgToken: configID,
 	})
 	if err != nil {

--- a/example/audit/root/main.go
+++ b/example/audit/root/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	auditcli, err := audit.New(&pangea.Config{
 		Token:    token,
-		Domain:   "dev.pangea.cloud/",
+		Domain:   os.Getenv("PANGEA_DOMAIN"),
 		Insecure: false,
 		CfgToken: configID,
 	})

--- a/example/audit/root/main.go
+++ b/example/audit/root/main.go
@@ -22,11 +22,9 @@ func main() {
 	}
 
 	auditcli, err := audit.New(&pangea.Config{
-		Token: token,
-		EndpointConfig: &pangea.EndpointConfig{
-			Scheme: "https",
-			CSP:    "aws",
-		},
+		Token:    token,
+		Domain:   "dev.pangea.cloud/",
+		Insecure: false,
 		CfgToken: configID,
 	})
 	if err != nil {

--- a/example/audit/search/main.go
+++ b/example/audit/search/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	auditcli, err := audit.New(&pangea.Config{
 		Token:    token,
-		Domain:   "dev.pangea.cloud/",
+		Domain:   os.Getenv("PANGEA_DOMAIN"),
 		Insecure: false,
 		CfgToken: configID,
 	})

--- a/example/audit/search/main.go
+++ b/example/audit/search/main.go
@@ -22,11 +22,9 @@ func main() {
 	}
 
 	auditcli, err := audit.New(&pangea.Config{
-		Token: token,
-		EndpointConfig: &pangea.EndpointConfig{
-			Scheme: "https",
-			CSP:    "aws",
-		},
+		Token:    token,
+		Domain:   "dev.pangea.cloud/",
+		Insecure: false,
 		CfgToken: configID,
 	})
 	if err != nil {

--- a/example/demo_app/app.go
+++ b/example/demo_app/app.go
@@ -47,11 +47,9 @@ func (a *App) Initialize(pangea_token string) {
 	embargoConfigID := os.Getenv("EMBARGO_CONFIG_ID")
 
 	a.pangea_embargo, err = embargo.New(&pangea.Config{
-		Token: a.pangea_token,
-		EndpointConfig: &pangea.EndpointConfig{
-			Scheme: "https",
-			CSP:    csp,
-		},
+		Token:    a.pangea_token,
+		Domain:   "dev.pangea.cloud/",
+		Insecure: false,
 		CfgToken: embargoConfigID,
 	})
 	if err != nil {
@@ -61,11 +59,9 @@ func (a *App) Initialize(pangea_token string) {
 	auditConfigID := os.Getenv("AUDIT_CONFIG_ID")
 
 	a.pangea_audit, err = audit.New(&pangea.Config{
-		Token: a.pangea_token,
-		EndpointConfig: &pangea.EndpointConfig{
-			Scheme: "https",
-			CSP:    csp,
-		},
+		Token:    a.pangea_token,
+		Domain:   "dev.pangea.cloud/",
+		Insecure: false,
 		CfgToken: auditConfigID,
 	})
 	if err != nil {
@@ -75,11 +71,9 @@ func (a *App) Initialize(pangea_token string) {
 	redactConfigID := os.Getenv("REDACT_CONFIG_ID")
 
 	a.pangea_redact, err = redact.New(&pangea.Config{
-		Token: a.pangea_token,
-		EndpointConfig: &pangea.EndpointConfig{
-			Scheme: "https",
-			CSP:    csp,
-		},
+		Token:    a.pangea_token,
+		Domain:   "dev.pangea.cloud/",
+		Insecure: false,
 		CfgToken: redactConfigID,
 	})
 	if err != nil {

--- a/example/demo_app/app.go
+++ b/example/demo_app/app.go
@@ -48,7 +48,7 @@ func (a *App) Initialize(pangea_token string) {
 
 	a.pangea_embargo, err = embargo.New(&pangea.Config{
 		Token:    a.pangea_token,
-		Domain:   "dev.pangea.cloud/",
+		Domain:   os.Getenv("PANGEA_DOMAIN"),
 		Insecure: false,
 		CfgToken: embargoConfigID,
 	})
@@ -60,7 +60,7 @@ func (a *App) Initialize(pangea_token string) {
 
 	a.pangea_audit, err = audit.New(&pangea.Config{
 		Token:    a.pangea_token,
-		Domain:   "dev.pangea.cloud/",
+		Domain:   os.Getenv("PANGEA_DOMAIN"),
 		Insecure: false,
 		CfgToken: auditConfigID,
 	})
@@ -72,7 +72,7 @@ func (a *App) Initialize(pangea_token string) {
 
 	a.pangea_redact, err = redact.New(&pangea.Config{
 		Token:    a.pangea_token,
-		Domain:   "dev.pangea.cloud/",
+		Domain:   os.Getenv("PANGEA_DOMAIN"),
 		Insecure: false,
 		CfgToken: redactConfigID,
 	})

--- a/example/embargo/ip_check/main.go
+++ b/example/embargo/ip_check/main.go
@@ -23,11 +23,9 @@ func main() {
 	}
 
 	embargocli, err := embargo.New(&pangea.Config{
-		Token: token,
-		EndpointConfig: &pangea.EndpointConfig{
-			Scheme: "https",
-			CSP:    "aws",
-		},
+		Token:    token,
+		Domain:   "dev.pangea.cloud/",
+		Insecure: false,
 		CfgToken: configID,
 	})
 	if err != nil {

--- a/example/embargo/ip_check/main.go
+++ b/example/embargo/ip_check/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	embargocli, err := embargo.New(&pangea.Config{
 		Token:    token,
-		Domain:   "dev.pangea.cloud/",
+		Domain:   os.Getenv("PANGEA_DOMAIN"),
 		Insecure: false,
 		CfgToken: configID,
 	})

--- a/example/embargo/iso_check/main.go
+++ b/example/embargo/iso_check/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	embargocli, err := embargo.New(&pangea.Config{
 		Token:    token,
-		Domain:   "dev.pangea.cloud/",
+		Domain:   os.Getenv("PANGEA_DOMAIN"),
 		Insecure: false,
 		CfgToken: configID,
 	})

--- a/example/embargo/iso_check/main.go
+++ b/example/embargo/iso_check/main.go
@@ -24,11 +24,8 @@ func main() {
 
 	embargocli, err := embargo.New(&pangea.Config{
 		Token:    token,
-		Endpoint: "dev.pangea.cloud/",
-		EndpointConfig: &pangea.EndpointConfig{
-			Scheme: "https",
-			CSP:    "aws",
-		},
+		Domain:   "dev.pangea.cloud/",
+		Insecure: false,
 		CfgToken: configID,
 	})
 	if err != nil {

--- a/example/redact/structured/main.go
+++ b/example/redact/structured/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	redactcli, err := redact.New(&pangea.Config{
 		Token:    token,
-		Domain:   "dev.pangea.cloud/",
+		Domain:   os.Getenv("PANGEA_DOMAIN"),
 		Insecure: false,
 		CfgToken: configID,
 	})

--- a/example/redact/structured/main.go
+++ b/example/redact/structured/main.go
@@ -26,11 +26,9 @@ func main() {
 	}
 
 	redactcli, err := redact.New(&pangea.Config{
-		Token: token,
-		EndpointConfig: &pangea.EndpointConfig{
-			Scheme: "https",
-			CSP:    "aws",
-		},
+		Token:    token,
+		Domain:   "dev.pangea.cloud/",
+		Insecure: false,
 		CfgToken: configID,
 	})
 	if err != nil {

--- a/example/redact/text/main.go
+++ b/example/redact/text/main.go
@@ -22,11 +22,9 @@ func main() {
 	}
 
 	redactcli, err := redact.New(&pangea.Config{
-		Token: token,
-		EndpointConfig: &pangea.EndpointConfig{
-			Scheme: "https",
-			CSP:    "aws",
-		},
+		Token:    token,
+		Domain:   "dev.pangea.cloud/",
+		Insecure: false,
 		CfgToken: configID,
 	})
 	if err != nil {

--- a/example/redact/text/main.go
+++ b/example/redact/text/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	redactcli, err := redact.New(&pangea.Config{
 		Token:    token,
-		Domain:   "dev.pangea.cloud/",
+		Domain:   os.Getenv("PANGEA_DOMAIN"),
 		Insecure: false,
 		CfgToken: configID,
 	})

--- a/internal/pangeatesting/integration.go
+++ b/internal/pangeatesting/integration.go
@@ -24,12 +24,12 @@ var (
 
 func initConfig() {
 	integrationConfig.Token = os.Getenv("PANGEA_TEST_INTEGRATION_TOKEN")
-	integrationConfig.Endpoint = os.Getenv("PANGEA_TEST_INTEGRATION_ENDPOINT")
+	integrationConfig.Domain = os.Getenv("PANGEA_TEST_INTEGRATION_ENDPOINT")
 }
 
 func IntegrationConfig(t *testing.T) *pangea.Config {
 	onceInit.Do(initConfig)
-	if integrationConfig.Token == "" || integrationConfig.Endpoint == "" {
+	if integrationConfig.Token == "" || integrationConfig.Domain == "" {
 		t.Skip("set PANGEA_TEST_INTEGRATION_TOKEN and PANGEA_TEST_INTEGRATION_ENDPOINT env variables to run this test")
 	}
 	return integrationConfig

--- a/internal/pangeatesting/pangeatesting.go
+++ b/internal/pangeatesting/pangeatesting.go
@@ -38,9 +38,19 @@ func SetupServer() (mux *http.ServeMux, serverURL string, teardown func()) {
 }
 
 func TestConfig(url string) *pangea.Config {
+	// Clean scheme. It will be adden after decide if it should be secure o insecure
+	// It only happens on testing because of local server
+	if strings.HasPrefix(url, "https://") {
+		url = strings.TrimPrefix(url, "https://")
+	} else if strings.HasPrefix(url, "http://") {
+		url = strings.TrimPrefix(url, "http://")
+	}
+
 	return &pangea.Config{
-		Token:    "TestToken",
-		Endpoint: url,
+		Token:      "TestToken",
+		Domain:     url,
+		Insecure:   true,
+		Enviroment: "local",
 	}
 }
 
@@ -65,16 +75,16 @@ func TestBody(t *testing.T, r *http.Request, want string) {
 func TestNewRequestAndDoFailure(t *testing.T, method string, f func(cfg *pangea.Config) error) {
 	t.Helper()
 
-	emptyEndpointCfg := &pangea.Config{Endpoint: ""}
-	doErr := f(emptyEndpointCfg)
+	emptyDomainCfg := &pangea.Config{Domain: ""}
+	doErr := f(emptyDomainCfg)
 	if doErr == nil {
 		t.Fatalf("call to method %v with empty Enpoint got nil err, want error", method)
 	}
 
-	badUrlCfg := &pangea.Config{Endpoint: "htt://   "}
+	badUrlCfg := &pangea.Config{Domain: "htt://   "}
 	newRequestErr := f(badUrlCfg)
 	if newRequestErr == nil {
-		t.Fatalf("call to method %v with bad Endpoint got nil err, want error", method)
+		t.Fatalf("call to method %v with bad Domain got nil err, want error", method)
 	}
 }
 

--- a/pangea/pangea_test.go
+++ b/pangea/pangea_test.go
@@ -16,7 +16,7 @@ import (
 
 func testClient(t *testing.T, url string) *pangea.Client {
 	t.Helper()
-	return pangea.NewClient("service", &pangea.Config{Token: "TestToken", Endpoint: url})
+	return pangea.NewClient("service", pangeatesting.TestConfig(url))
 }
 
 func TestDo_When_Nil_Context_Is_Given_It_Returns_Error(t *testing.T) {
@@ -274,17 +274,13 @@ func TestDo_When_Client_Can_Not_UnMarshall_Response_Result_Into_Body_It_Returns_
 func TestDo_With_Retries_Success(t *testing.T) {
 	mux, url, teardown := pangeatesting.SetupServer()
 	defer teardown()
+	cfg := pangeatesting.TestConfig(url)
+	cfg.Retry = true
+	cfg.RetryConfig = &pangea.RetryConfig{
+		RetryMax: 1,
+	}
 
-	client := pangea.NewClient("service", &pangea.Config{
-		Token:    "TestToken",
-		Endpoint: url,
-		Retry:    true,
-		RetryConfig: &pangea.RetryConfig{
-			RetryMax: 1,
-		},
-	},
-	)
-
+	client := pangea.NewClient("service", cfg)
 	req, _ := client.NewRequest("POST", "test", nil)
 
 	handler := func() func(w http.ResponseWriter, r *http.Request) {
@@ -326,16 +322,13 @@ func TestDo_With_Retries_Success(t *testing.T) {
 func TestDo_With_Retries_Error(t *testing.T) {
 	mux, url, teardown := pangeatesting.SetupServer()
 	defer teardown()
+	cfg := pangeatesting.TestConfig(url)
+	cfg.Retry = true
+	cfg.RetryConfig = &pangea.RetryConfig{
+		RetryMax: 1,
+	}
 
-	client := pangea.NewClient("service", &pangea.Config{
-		Token:    "TestToken",
-		Endpoint: url,
-		Retry:    true,
-		RetryConfig: &pangea.RetryConfig{
-			RetryMax: 1,
-		},
-	},
-	)
+	client := pangea.NewClient("service", cfg)
 
 	req, _ := client.NewRequest("POST", "test", nil)
 


### PR DESCRIPTION
Unify domain url like python SDK
Remove CSP and Region variables
Add Enviroment variable to test locally (same as python SDK)
Fix test to fit new config format