### PR TITLE
Return parent object as response

### DIFF
--- a/example/audit/log/main.go
+++ b/example/audit/log/main.go
@@ -40,10 +40,10 @@ func main() {
 		Verbose:    pangea.Bool(true),
 	}
 
-	logOutput, _, err := auditcli.Log(ctx, input)
+	logResponse, err := auditcli.Log(ctx, input)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Println(pangea.Stringify(logOutput))
+	fmt.Println(pangea.Stringify(logResponse.Result))
 }

--- a/example/audit/results/main.go
+++ b/example/audit/results/main.go
@@ -37,19 +37,20 @@ func main() {
 		IncludeMembershipProof: pangea.Bool(true),
 	}
 
-	searchOutput, _, err := auditcli.Search(ctx, input)
+	searchResponse, err := auditcli.Search(ctx, input)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	verified, err := audit.VerifyAuditRecordsWithArweave(ctx, searchOutput.Root, searchOutput.Events.VerifiableRecords(), true)
+	verified, err := audit.VerifyAuditRecordsWithArweave(ctx, searchResponse.Result.Root, searchResponse.Result.Events.VerifiableRecords(), true)
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	// FIXME: Should we check if this verified is empty?
 	if !verified {
 		log.Fatal("failed validation of audit records")
 	}
 
-	fmt.Println(pangea.Stringify(searchOutput))
+	fmt.Println(pangea.Stringify(searchResponse.Result))
 }

--- a/example/audit/root/main.go
+++ b/example/audit/root/main.go
@@ -36,10 +36,10 @@ func main() {
 		TreeSize: pangea.Int(10),
 	}
 
-	rootOutput, _, err := auditcli.Root(ctx, input)
+	rootResponse, err := auditcli.Root(ctx, input)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Println(pangea.Stringify(rootOutput))
+	fmt.Println(pangea.Stringify(rootResponse.Result))
 }

--- a/example/audit/search/main.go
+++ b/example/audit/search/main.go
@@ -37,12 +37,12 @@ func main() {
 		IncludeMembershipProof: pangea.Bool(true),
 	}
 
-	searchOutput, _, err := auditcli.Search(ctx, input)
+	searchResponse, err := auditcli.Search(ctx, input)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	verified, err := audit.VerifyAuditRecordsWithArweave(ctx, searchOutput.Root, searchOutput.Events.VerifiableRecords(), true)
+	verified, err := audit.VerifyAuditRecordsWithArweave(ctx, searchResponse.Result.Root, searchResponse.Result.Events.VerifiableRecords(), true)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -51,5 +51,5 @@ func main() {
 		log.Fatal("failed validation of audit records")
 	}
 
-	fmt.Println(pangea.Stringify(searchOutput))
+	fmt.Println(pangea.Stringify(searchResponse.Result))
 }

--- a/example/demo_app/app.go
+++ b/example/demo_app/app.go
@@ -172,17 +172,18 @@ func (a *App) uploadResume(w http.ResponseWriter, r *http.Request) {
 			Verbose:    pangea.Bool(false),
 		}
 
-		logOutput, _, err := a.pangea_audit.Log(ctx, audinput)
+		logResponse, err := a.pangea_audit.Log(ctx, audinput)
 		if err != nil {
 			log.Println("[App.uploadResume] audit log error: ", err.Error())
 		} else {
-			log.Println(pangea.Stringify(logOutput))
+			log.Println(pangea.Stringify(logResponse.Result))
 		}
 
 		respondWithError(w, http.StatusForbidden, "Submissions from sanctioned country not allowed")
 		return
 	}
 
+	// FIXME: What is StatusCandidate? Should we remove it?
 	// set status to CANDIDATE
 	emp.Status = StatusCandidate
 
@@ -193,14 +194,15 @@ func (a *App) uploadResume(w http.ResponseWriter, r *http.Request) {
 	}
 	redinput.SetData(emp)
 
-	redactOutput, _, err := a.pangea_redact.RedactStructured(ctx, redinput)
+	redactResponse, err := a.pangea_redact.RedactStructured(ctx, redinput)
 	redacted := ""
 	if err != nil {
 		log.Println("[App.uploadResume] redact error: ", err.Error())
 	} else {
-		log.Println(pangea.Stringify(redactOutput.RedactedData))
+		log.Println(pangea.Stringify(redactResponse.Result.RedactedData))
+		// FIXME: What about employee?
 		var redactedEmployee employee
-		redactOutput.GetRedactedData(&redactedEmployee)
+		redactResponse.Result.GetRedactedData(&redactedEmployee)
 		log.Printf("%+v", redactedEmployee)
 	}
 
@@ -220,11 +222,11 @@ func (a *App) uploadResume(w http.ResponseWriter, r *http.Request) {
 			Verbose:    pangea.Bool(false),
 		}
 
-		logOutput, _, err1 := a.pangea_audit.Log(ctx, audinput)
+		logResponse, err1 := a.pangea_audit.Log(ctx, audinput)
 		if err1 != nil {
 			log.Println("[App.uploadResume] audit log error: ", err1.Error())
 		} else {
-			log.Println(pangea.Stringify(logOutput))
+			log.Println(pangea.Stringify(logResponse.Result))
 		}
 
 		log.Println("[App.uploadResume] datastore error: ", err.Error())
@@ -251,11 +253,11 @@ func (a *App) uploadResume(w http.ResponseWriter, r *http.Request) {
 		Verbose:    pangea.Bool(false),
 	}
 
-	logOutput, _, err := a.pangea_audit.Log(ctx, audinput)
+	logResponse, err := a.pangea_audit.Log(ctx, audinput)
 	if err != nil {
 		log.Println("[App.uploadResume] audit log error: ", err.Error())
 	} else {
-		log.Println(pangea.Stringify(logOutput))
+		log.Println(pangea.Stringify(logResponse.Result))
 	}
 
 	respondWithJSON(w, http.StatusCreated, resp)
@@ -295,11 +297,11 @@ func (a *App) fetchEmployeeRecord(w http.ResponseWriter, r *http.Request) {
 			Verbose:    pangea.Bool(false),
 		}
 
-		logOutput, _, err1 := a.pangea_audit.Log(ctx, audinput)
+		logResponse, err1 := a.pangea_audit.Log(ctx, audinput)
 		if err1 != nil {
 			log.Println("[App.fetchEmployeeRecord] audit log error: ", err1.Error())
 		} else {
-			log.Println(pangea.Stringify(logOutput))
+			log.Println(pangea.Stringify(logResponse.Result))
 		}
 
 		log.Println("[App.fetchEmployeeRecord] datastore error: ", err.Error())
@@ -321,11 +323,11 @@ func (a *App) fetchEmployeeRecord(w http.ResponseWriter, r *http.Request) {
 		Verbose:    pangea.Bool(false),
 	}
 
-	logOutput, _, err := a.pangea_audit.Log(ctx, audinput)
+	logResponse, err := a.pangea_audit.Log(ctx, audinput)
 	if err != nil {
 		log.Println("[App.fetchEmployeeRecord] audit log error: ", err.Error())
 	} else {
-		log.Println(pangea.Stringify(logOutput))
+		log.Println(pangea.Stringify(logResponse.Result))
 	}
 
 	respondWithJSON(w, http.StatusOK, emp)
@@ -411,11 +413,11 @@ func (a *App) updateEmployee(w http.ResponseWriter, r *http.Request) {
 		Verbose:    pangea.Bool(false),
 	}
 
-	logOutput, _, err := a.pangea_audit.Log(ctx, audinput)
+	logResponse, err := a.pangea_audit.Log(ctx, audinput)
 	if err != nil {
 		log.Println("[App.fetchEmployeeRecord] audit log error: ", err.Error())
 	} else {
-		log.Println(pangea.Stringify(logOutput))
+		log.Println(pangea.Stringify(logResponse.Result))
 	}
 
 	respondWithJSON(w, http.StatusOK, resp)

--- a/example/embargo/ip_check/main.go
+++ b/example/embargo/ip_check/main.go
@@ -37,10 +37,10 @@ func main() {
 		IP: pangea.String("213.24.238.26"),
 	}
 
-	checkOutput, _, err := embargocli.IPCheck(ctx, input)
+	checkResponse, err := embargocli.IPCheck(ctx, input)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Println(pangea.Stringify(checkOutput))
+	fmt.Println(pangea.Stringify(checkResponse.Result))
 }

--- a/example/embargo/iso_check/main.go
+++ b/example/embargo/iso_check/main.go
@@ -37,10 +37,10 @@ func main() {
 		ISOCode: pangea.String("CU"),
 	}
 
-	checkOutput, _, err := embargocli.ISOCheck(ctx, input)
+	checkResponse, err := embargocli.ISOCheck(ctx, input)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Println(pangea.Stringify(checkOutput))
+	fmt.Println(pangea.Stringify(checkResponse.Result))
 }

--- a/example/redact/structured/main.go
+++ b/example/redact/structured/main.go
@@ -47,13 +47,13 @@ func main() {
 	}
 	input.SetData(rawData)
 
-	redactOutput, _, err := redactcli.RedactStructured(ctx, input)
+	redactResponse, err := redactcli.RedactStructured(ctx, input)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	var redactedData yourCustomDataStruct
-	redactOutput.GetRedactedData(&redactedData)
+	redactResponse.Result.GetRedactedData(&redactedData)
 
 	fmt.Println(pangea.Stringify(redactedData))
 }

--- a/example/redact/text/main.go
+++ b/example/redact/text/main.go
@@ -36,10 +36,10 @@ func main() {
 		Text: pangea.String("my phone number is 123-456-7890"),
 	}
 
-	redactOutput, _, err := redactcli.Redact(ctx, input)
+	redactResponse, err := redactcli.Redact(ctx, input)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Println(pangea.Stringify(redactOutput))
+	fmt.Println(pangea.Stringify(redactResponse.Result))
 }

--- a/pangea/error.go
+++ b/pangea/error.go
@@ -11,9 +11,10 @@ type APIError struct {
 	// the HTTP response
 	HTTPResponse *http.Response
 
-	// the reponse metadata of the request if any
-	ResponseMetadata *ResponseMetadata
+	// the reponse header of the request if any
+	ResponseHeader *ResponseHeader
 
+	// FIXME: Maybe we should call it RawResult
 	// the result of the request
 	Result json.RawMessage
 
@@ -21,11 +22,11 @@ type APIError struct {
 	Err error
 }
 
-func NewAPIError(err error, r *http.Response, metadata *ResponseMetadata) *APIError {
+func NewAPIError(err error, r *http.Response, header *ResponseHeader) *APIError {
 	return &APIError{
-		Err:              err,
-		HTTPResponse:     r,
-		ResponseMetadata: metadata,
+		Err:            err,
+		HTTPResponse:   r,
+		ResponseHeader: header,
 	}
 }
 
@@ -34,8 +35,8 @@ func (e *APIError) Error() string {
 	if e.HTTPResponse != nil {
 		b.WriteString(fmt.Sprintf("pangea: %v %v", e.HTTPResponse.Request.Method, e.HTTPResponse.Request.URL))
 		pad(b, ": ")
-		if e.ResponseMetadata != nil {
-			b.WriteString(fmt.Sprintf("%v", e.ResponseMetadata.String()))
+		if e.ResponseHeader != nil {
+			b.WriteString(fmt.Sprintf("%v", e.ResponseHeader.String()))
 		} else {
 			b.WriteString(fmt.Sprintf("%v", e.HTTPResponse.StatusCode))
 		}
@@ -56,12 +57,12 @@ type UnMarshalError struct {
 	Bytes []byte
 }
 
-func NewUnMarshalError(err error, bytes []byte, r *http.Response, metadata *ResponseMetadata) *UnMarshalError {
+func NewUnMarshalError(err error, bytes []byte, r *http.Response, header *ResponseHeader) *UnMarshalError {
 	return &UnMarshalError{
 		APIError: APIError{
-			Err:              err,
-			HTTPResponse:     r,
-			ResponseMetadata: metadata,
+			Err:            err,
+			HTTPResponse:   r,
+			ResponseHeader: header,
 		},
 		Bytes: bytes,
 	}
@@ -91,7 +92,7 @@ func pad(b *bytes.Buffer, str string) {
 }
 
 type AcceptedError struct {
-	ResponseMetadata
+	ResponseHeader
 }
 
 func (e *AcceptedError) Error() string {

--- a/pangea/pangea_test.go
+++ b/pangea/pangea_test.go
@@ -67,14 +67,14 @@ func TestDo_When_Server_Returns_400_It_Returns_Error(t *testing.T) {
 	if !ok {
 		t.Fatalf("Expected pangea.APIError, got %T", err)
 	}
-	if pangeaErr.ResponseMetadata == nil {
+	if pangeaErr.ResponseHeader == nil {
 		t.Fatal("Expected ResponseMetadata to be non-nil")
 	}
-	if pangeaErr.ResponseMetadata.StatusCode == nil {
+	if pangeaErr.ResponseHeader.StatusCode == nil {
 		t.Fatal("Expected non-nil status code")
 	}
-	if *pangeaErr.ResponseMetadata.StatusCode != http.StatusBadRequest {
-		t.Errorf("Expected status code %d, got %d", http.StatusBadRequest, *pangeaErr.ResponseMetadata.StatusCode)
+	if *pangeaErr.ResponseHeader.StatusCode != http.StatusBadRequest {
+		t.Errorf("Expected status code %d, got %d", http.StatusBadRequest, *pangeaErr.ResponseHeader.StatusCode)
 	}
 }
 
@@ -108,14 +108,14 @@ func TestDo_When_Server_Returns_500_It_Returns_Error(t *testing.T) {
 	if !ok {
 		t.Fatalf("Expected pangea.APIError, got %v", err)
 	}
-	if pangeaErr.ResponseMetadata == nil {
+	if pangeaErr.ResponseHeader == nil {
 		t.Fatal("Expected ResponseMetadata to be non-nil")
 	}
-	if pangeaErr.ResponseMetadata.StatusCode == nil {
+	if pangeaErr.ResponseHeader.StatusCode == nil {
 		t.Fatal("Expected non-nil status code")
 	}
-	if *pangeaErr.ResponseMetadata.StatusCode != http.StatusInternalServerError {
-		t.Errorf("Expected status code %d, got %d", http.StatusInternalServerError, *pangeaErr.ResponseMetadata.StatusCode)
+	if *pangeaErr.ResponseHeader.StatusCode != http.StatusInternalServerError {
+		t.Errorf("Expected status code %d, got %d", http.StatusInternalServerError, *pangeaErr.ResponseHeader.StatusCode)
 	}
 }
 
@@ -378,11 +378,11 @@ func TestDo_When_Server_Returns_202_It_Returns_AcceptedError(t *testing.T) {
 	if !ok {
 		t.Fatalf("Expected pangea.AcceptedError, got %T", err)
 	}
-	if pangeaErr.ResponseMetadata.StatusCode == nil {
+	if pangeaErr.ResponseHeader.StatusCode == nil {
 		t.Fatal("Expected non-nil status code")
 	}
-	if *pangeaErr.ResponseMetadata.StatusCode != http.StatusAccepted {
-		t.Errorf("Expected status code %d, got %d", http.StatusAccepted, *pangeaErr.ResponseMetadata.StatusCode)
+	if *pangeaErr.ResponseHeader.StatusCode != http.StatusAccepted {
+		t.Errorf("Expected status code %d, got %d", http.StatusAccepted, *pangeaErr.ResponseHeader.StatusCode)
 	}
 }
 

--- a/pangea/response.go
+++ b/pangea/response.go
@@ -1,10 +1,12 @@
 package pangea
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 )
 
-type ResponseMetadata struct {
+type ResponseHeader struct {
 	// The request ID
 	RequestID *string `json:"request_id"`
 
@@ -24,7 +26,14 @@ type ResponseMetadata struct {
 	Summary *string `json:"summary"`
 }
 
-func (r *ResponseMetadata) String() string {
+type Response struct {
+	ResponseHeader
+	HTTPResponse *http.Response
+	// Query raw result
+	RawResult json.RawMessage `json:"result"`
+}
+
+func (r *ResponseHeader) String() string {
 	if r == nil {
 		return ""
 	}

--- a/pangea/response_test.go
+++ b/pangea/response_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pangeacyber/go-pangea/pangea"
 )
 
-func TestResponseMetadata_String(t *testing.T) {
+func TestResponseHeader_String(t *testing.T) {
 	want := "request_id: some-id, " +
 		"request_time: 1970-01-01T00:00:00Z, " +
 		"response_time: 1970-01-01T00:00:10Z, " +
@@ -14,7 +14,7 @@ func TestResponseMetadata_String(t *testing.T) {
 		"status: I'm a teapot, " +
 		"summary: I'm a teapot"
 
-	metadata := &pangea.ResponseMetadata{
+	metadata := &pangea.ResponseHeader{
 		RequestID:    pangea.String("some-id"),
 		RequestTime:  pangea.String("1970-01-01T00:00:00Z"),
 		ResponseTime: pangea.String("1970-01-01T00:00:10Z"),
@@ -28,9 +28,9 @@ func TestResponseMetadata_String(t *testing.T) {
 	}
 }
 
-func TestResponseMetadata_String_When_ResponseMetadata_Is_Nil_Return_EmptyString(t *testing.T) {
-	var metadata *pangea.ResponseMetadata
-	if got := metadata.String(); got != "" {
+func TestResponseHeader_String_When_ResponseHeader_Is_Nil_Return_EmptyString(t *testing.T) {
+	var header *pangea.ResponseHeader
+	if got := header.String(); got != "" {
 		t.Errorf("got %v, want empty string", got)
 	}
 }

--- a/service/audit/api_test.go
+++ b/service/audit/api_test.go
@@ -47,7 +47,7 @@ func TestLog(t *testing.T) {
 		Verbose:    pangea.Bool(true),
 	}
 	ctx := context.Background()
-	got, _, err := client.Log(ctx, input)
+	got, err := client.Log(ctx, input)
 
 	assert.NoError(t, err)
 
@@ -58,7 +58,7 @@ func TestLog(t *testing.T) {
 			Message: pangea.String("test"),
 		},
 	}
-	assert.Equal(t, want, got)
+	assert.Equal(t, want, got.Result)
 }
 
 func TestSearch(t *testing.T) {
@@ -109,7 +109,7 @@ func TestSearch(t *testing.T) {
 		IncludeMembershipProof: pangea.Bool(true),
 	}
 	ctx := context.Background()
-	got, _, err := client.Search(ctx, input)
+	got, err := client.Search(ctx, input)
 
 	assert.NoError(t, err)
 
@@ -134,7 +134,7 @@ func TestSearch(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, want, got)
+	assert.Equal(t, want, got.Result)
 }
 
 func TestSearchResults(t *testing.T) {
@@ -193,7 +193,7 @@ func TestSearchResults(t *testing.T) {
 		Limit:                  pangea.Int(50),
 	}
 	ctx := context.Background()
-	got, _, err := client.SearchResults(ctx, input)
+	got, err := client.SearchResults(ctx, input)
 
 	assert.NoError(t, err)
 
@@ -225,7 +225,7 @@ func TestSearchResults(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, want, got)
+	assert.Equal(t, want, got.Result)
 }
 
 func TestRoot(t *testing.T) {
@@ -263,7 +263,7 @@ func TestRoot(t *testing.T) {
 		TreeSize: pangea.Int(11),
 	}
 	ctx := context.Background()
-	got, _, err := client.Root(ctx, input)
+	got, err := client.Root(ctx, input)
 
 	assert.NoError(t, err)
 
@@ -279,13 +279,13 @@ func TestRoot(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, want, got)
+	assert.Equal(t, want, got.Result)
 }
 
 func TestLogError(t *testing.T) {
 	f := func(cfg *pangea.Config) error {
 		client, _ := audit.New(cfg)
-		_, _, err := client.Log(context.Background(), nil)
+		_, err := client.Log(context.Background(), nil)
 		return err
 	}
 	pangeatesting.TestNewRequestAndDoFailure(t, "Audit.Log", f)
@@ -294,7 +294,7 @@ func TestLogError(t *testing.T) {
 func TestSearchError(t *testing.T) {
 	f := func(cfg *pangea.Config) error {
 		client, _ := audit.New(cfg)
-		_, _, err := client.Search(context.Background(), nil)
+		_, err := client.Search(context.Background(), nil)
 		return err
 	}
 	pangeatesting.TestNewRequestAndDoFailure(t, "Audit.Search", f)
@@ -303,7 +303,7 @@ func TestSearchError(t *testing.T) {
 func TestSearchResultsError(t *testing.T) {
 	f := func(cfg *pangea.Config) error {
 		client, _ := audit.New(cfg)
-		_, _, err := client.SearchResults(context.Background(), nil)
+		_, err := client.SearchResults(context.Background(), nil)
 		return err
 	}
 	pangeatesting.TestNewRequestAndDoFailure(t, "Audit.SearchResults", f)
@@ -312,7 +312,7 @@ func TestSearchResultsError(t *testing.T) {
 func TestRootError(t *testing.T) {
 	f := func(cfg *pangea.Config) error {
 		client, _ := audit.New(cfg)
-		_, _, err := client.Root(context.Background(), nil)
+		_, err := client.Root(context.Background(), nil)
 		return err
 	}
 	pangeatesting.TestNewRequestAndDoFailure(t, "Audit.Root", f)

--- a/service/audit/integration_test.go
+++ b/service/audit/integration_test.go
@@ -29,18 +29,18 @@ func Test_Integration_Root(t *testing.T) {
 	client, _ := audit.New(cfg)
 
 	input := &audit.RootInput{}
-	out, _, err := client.Root(ctx, input)
+	out, err := client.Root(ctx, input)
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}
 
-	assert.NotNil(t, out)
-	assert.NotNil(t, out.Data)
-	assert.NotNil(t, out.Data.RootHash)
-	assert.NotEmpty(t, *out.Data.RootHash)
-	assert.NotNil(t, out.Data.TreeName)
-	assert.NotEmpty(t, *out.Data.TreeName)
-	assert.NotNil(t, out.Data.Size)
+	assert.NotNil(t, out.Result)
+	assert.NotNil(t, out.Result.Data)
+	assert.NotNil(t, out.Result.Data.RootHash)
+	assert.NotEmpty(t, *out.Result.Data.RootHash)
+	assert.NotNil(t, out.Result.Data.TreeName)
+	assert.NotEmpty(t, *out.Result.Data.TreeName)
+	assert.NotNil(t, out.Result.Data.Size)
 	// TODO: Fix test
 	// assert.NotNil(t, out.Data.ConsistencyProof)
 }
@@ -55,17 +55,17 @@ func Test_Integration_Search(t *testing.T) {
 	input := &audit.SearchInput{
 		Query: pangea.String("message:test"),
 	}
-	out, _, err := client.Search(ctx, input)
+	out, err := client.Search(ctx, input)
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}
 
-	assert.NotNil(t, out)
-	assert.NotNil(t, out.ID)
-	assert.NotEmpty(t, out.ID)
-	assert.NotNil(t, out.ExpiresAt)
-	assert.NotNil(t, out.Count)
-	assert.NotNil(t, out.Events)
+	assert.NotNil(t, out.Result)
+	assert.NotNil(t, out.Result.ID)
+	assert.NotEmpty(t, out.Result.ID)
+	assert.NotNil(t, out.Result.ExpiresAt)
+	assert.NotNil(t, out.Result.Count)
+	assert.NotNil(t, out.Result.Events)
 }
 
 func Test_Integration_SearchResults(t *testing.T) {
@@ -77,22 +77,22 @@ func Test_Integration_SearchResults(t *testing.T) {
 	searchInput := &audit.SearchInput{
 		Query: pangea.String("message:test"),
 	}
-	searchOut, _, err := client.Search(ctx, searchInput)
+	searchOut, err := client.Search(ctx, searchInput)
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}
 
-	assert.NotNil(t, searchOut)
-	assert.NotNil(t, searchOut.ID)
+	assert.NotNil(t, searchOut.Result)
+	assert.NotNil(t, searchOut.Result.ID)
 
 	searchResultInput := &audit.SearchResultInput{
-		ID: searchOut.ID,
+		ID: searchOut.Result.ID,
 	}
-	out, _, err := client.SearchResults(ctx, searchResultInput)
+	out, err := client.SearchResults(ctx, searchResultInput)
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}
 
-	assert.NotNil(t, out.Events)
-	assert.NotNil(t, out.Count)
+	assert.NotNil(t, out.Result.Events)
+	assert.NotNil(t, out.Result.Count)
 }

--- a/service/audit/service.go
+++ b/service/audit/service.go
@@ -9,10 +9,10 @@ import (
 )
 
 type Client interface {
-	Log(context.Context, *LogInput) (*LogOutput, *pangea.Response, error)
-	Search(context.Context, *SearchInput) (*SearchOutput, *pangea.Response, error)
-	SearchResults(context.Context, *SearchResultInput) (*SearchResultOutput, *pangea.Response, error)
-	Root(context.Context, *RootInput) (*RootOutput, *pangea.Response, error)
+	Log(context.Context, *LogInput) (*pangea.PangeaResponse[LogOutput], error)
+	Search(context.Context, *SearchInput) (*pangea.PangeaResponse[SearchOutput], error)
+	SearchResults(context.Context, *SearchResultInput) (*pangea.PangeaResponse[SearchResultOutput], error)
+	Root(context.Context, *RootInput) (*pangea.PangeaResponse[RootOutput], error)
 }
 
 type Audit struct {

--- a/service/embargo/api.go
+++ b/service/embargo/api.go
@@ -12,23 +12,26 @@ import (
 //
 // Example:
 //
-//  input := &embargo.IPCheckInput{
-//  	IP: pangea.String("213.24.238.26"),
-//  }
+//	input := &embargo.IPCheckInput{
+//		IP: pangea.String("213.24.238.26"),
+//	}
 //
-//  checkOutput, _, err := embargocli.IPCheck(ctx, input)
-//
-func (e *Embargo) IPCheck(ctx context.Context, input *IPCheckInput) (*CheckOutput, *pangea.Response, error) {
+//	checkResponse, err := embargocli.IPCheck(ctx, input)
+func (e *Embargo) IPCheck(ctx context.Context, input *IPCheckInput) (*pangea.PangeaResponse[CheckOutput], error) {
 	req, err := e.Client.NewRequest("POST", "v1/ip/check", input)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	out := CheckOutput{}
 	resp, err := e.Client.Do(ctx, req, &out)
-	if err != nil {
-		return nil, resp, err
+	panresp := pangea.PangeaResponse[CheckOutput]{
+		Response: *resp,
+		Result:   &out,
 	}
-	return &out, resp, nil
+	if err != nil {
+		return &panresp, err
+	}
+	return &panresp, nil
 }
 
 // ISO Code Check
@@ -37,23 +40,29 @@ func (e *Embargo) IPCheck(ctx context.Context, input *IPCheckInput) (*CheckOutpu
 //
 // Example:
 //
-//  input := &embargo.ISOCheckInput{
-//  	ISOCode: pangea.String("CU"),
-//  }
+//	input := &embargo.ISOCheckInput{
+//		ISOCode: pangea.String("CU"),
+//	}
 //
-//  checkOutput, _, err := embargocli.ISOCheck(ctx, input)
-//
-func (e *Embargo) ISOCheck(ctx context.Context, input *ISOCheckInput) (*CheckOutput, *pangea.Response, error) {
+//	checkResponse, err := embargocli.ISOCheck(ctx, input)
+func (e *Embargo) ISOCheck(ctx context.Context, input *ISOCheckInput) (*pangea.PangeaResponse[CheckOutput], error) {
 	req, err := e.Client.NewRequest("POST", "v1/iso/check", input)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	out := CheckOutput{}
 	resp, err := e.Client.Do(ctx, req, &out)
+
 	if err != nil {
-		return nil, resp, err
+		return nil, err
 	}
-	return &out, resp, nil
+
+	panresp := pangea.PangeaResponse[CheckOutput]{
+		Response: *resp,
+		Result:   &out,
+	}
+
+	return &panresp, nil
 }
 
 type IPCheckInput struct {

--- a/service/embargo/api_test.go
+++ b/service/embargo/api_test.go
@@ -53,7 +53,7 @@ func TestISOCheck(t *testing.T) {
 		ISOCode: pangea.String("CU"),
 	}
 	ctx := context.Background()
-	got, _, err := client.ISOCheck(ctx, input)
+	got, err := client.ISOCheck(ctx, input)
 
 	assert.NoError(t, err)
 
@@ -74,7 +74,7 @@ func TestISOCheck(t *testing.T) {
 		Sanctions: []*embargo.Sanction{sanction},
 		Count:     pangea.Int(1),
 	}
-	assert.Equal(t, want, got)
+	assert.Equal(t, want, got.Result)
 }
 
 func TestIPCheck(t *testing.T) {
@@ -118,7 +118,7 @@ func TestIPCheck(t *testing.T) {
 		IP: pangea.String("200.0.16.2"),
 	}
 	ctx := context.Background()
-	got, _, err := client.IPCheck(ctx, input)
+	got, err := client.IPCheck(ctx, input)
 
 	assert.NoError(t, err)
 
@@ -139,13 +139,13 @@ func TestIPCheck(t *testing.T) {
 		Sanctions: []*embargo.Sanction{sanction},
 		Count:     pangea.Int(1),
 	}
-	assert.Equal(t, want, got)
+	assert.Equal(t, want, got.Result)
 }
 
 func TestCheckError(t *testing.T) {
 	f := func(cfg *pangea.Config) error {
 		client, _ := embargo.New(cfg)
-		_, _, err := client.ISOCheck(context.Background(), nil)
+		_, err := client.ISOCheck(context.Background(), nil)
 		return err
 	}
 	pangeatesting.TestNewRequestAndDoFailure(t, "Embargo.Check", f)

--- a/service/embargo/integration_test.go
+++ b/service/embargo/integration_test.go
@@ -26,12 +26,12 @@ func Test_Integration_Check(t *testing.T) {
 	input := &embargo.ISOCheckInput{
 		ISOCode: pangea.String("CU"),
 	}
-	out, _, err := client.ISOCheck(ctx, input)
+	out, err := client.ISOCheck(ctx, input)
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}
 
-	assert.NotNil(t, out)
-	assert.NotNil(t, out.Count)
-	assert.NotZero(t, *out.Count)
+	assert.NotNil(t, out.Result)
+	assert.NotNil(t, out.Result.Count)
+	assert.NotZero(t, *out.Result.Count)
 }

--- a/service/embargo/service.go
+++ b/service/embargo/service.go
@@ -7,8 +7,8 @@ import (
 )
 
 type Client interface {
-	IPCheck(ctx context.Context, input *IPCheckInput) (*CheckOutput, *pangea.Response, error)
-	ISOCheck(ctx context.Context, input *ISOCheckInput) (*CheckOutput, *pangea.Response, error)
+	IPCheck(ctx context.Context, input *IPCheckInput) (*pangea.PangeaResponse[CheckOutput], error)
+	ISOCheck(ctx context.Context, input *ISOCheckInput) (*pangea.PangeaResponse[CheckOutput], error)
 }
 
 type Embargo struct {

--- a/service/redact/api.go
+++ b/service/redact/api.go
@@ -13,24 +13,28 @@ import (
 //
 // Example:
 //
-//  input := &redact.TextInput{
-//  	Text: pangea.String("my phone number is 123-456-7890"),
-//  }
+//	input := &redact.TextInput{
+//		Text: pangea.String("my phone number is 123-456-7890"),
+//	}
 //
-//  redactOutput, _, err := redactcli.Redact(ctx, input)
-//
-func (r *Redact) Redact(ctx context.Context, input *TextInput) (*TextOutput, *pangea.Response, error) {
+//	redactResponse, err := redactcli.Redact(ctx, input)
+func (r *Redact) Redact(ctx context.Context, input *TextInput) (*pangea.PangeaResponse[TextOutput], error) {
 	req, err := r.Client.NewRequest("POST", "v1/redact", input)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	out := TextOutput{}
 	resp, err := r.Client.Do(ctx, req, &out)
+
 	if err != nil {
-		return nil, resp, err
+		return nil, err
+	}
+	panresp := pangea.PangeaResponse[TextOutput]{
+		Response: *resp,
+		Result:   &out,
 	}
 
-	return &out, resp, nil
+	return &panresp, nil
 }
 
 // Redact structured
@@ -39,36 +43,42 @@ func (r *Redact) Redact(ctx context.Context, input *TextInput) (*TextOutput, *pa
 //
 // Example:
 //
-//  type yourCustomDataStruct struct {
-//  	Secret string `json:"secret"`
-//  }
+//	type yourCustomDataStruct struct {
+//		Secret string `json:"secret"`
+//	}
 //
-//  input := &redact.StructuredInput{
-//  	JSONP: []*string{
-//  		pangea.String("$.secret"),
-//  	},
-//  }
-//  rawData := yourCustomDataStruct{
-//  	Secret: "My social security number is 0303456",
-//  }
-//  input.SetData(rawData)
+//	input := &redact.StructuredInput{
+//		JSONP: []*string{
+//			pangea.String("$.secret"),
+//		},
+//	}
+//	rawData := yourCustomDataStruct{
+//		Secret: "My social security number is 0303456",
+//	}
+//	input.SetData(rawData)
 //
-//  redactOutput, _, err := redactcli.RedactStructured(ctx, input)
-//
-func (r *Redact) RedactStructured(ctx context.Context, input *StructuredInput) (*StructuredOutput, *pangea.Response, error) {
+//	redactResponse, err := redactcli.RedactStructured(ctx, input)
+func (r *Redact) RedactStructured(ctx context.Context, input *StructuredInput) (*pangea.PangeaResponse[StructuredOutput], error) {
 	if input == nil {
 		input = &StructuredInput{}
 	}
 	req, err := r.Client.NewRequest("POST", "v1/redact_structured", input)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	out := StructuredOutput{}
 	resp, err := r.Client.Do(ctx, req, &out)
+
 	if err != nil {
-		return nil, resp, err
+		return nil, err
 	}
-	return &out, resp, nil
+
+	panresp := pangea.PangeaResponse[StructuredOutput]{
+		Response: *resp,
+		Result:   &out,
+	}
+
+	return &panresp, nil
 }
 
 type TextInput struct {

--- a/service/redact/api_test.go
+++ b/service/redact/api_test.go
@@ -38,14 +38,14 @@ func TestRedact(t *testing.T) {
 		Text: pangea.String("My phone number is: 110303456"),
 	}
 	ctx := context.Background()
-	got, _, err := client.Redact(ctx, input)
+	got, err := client.Redact(ctx, input)
 
 	assert.NoError(t, err)
 
 	want := &redact.TextOutput{
 		RedactedText: pangea.String("My phone number is: <PHONE_NUMBER>"),
 	}
-	assert.Equal(t, want, got)
+	assert.Equal(t, want, got.Result)
 }
 
 func TestRedactStructured(t *testing.T) {
@@ -89,21 +89,21 @@ func TestRedactStructured(t *testing.T) {
 	}
 	input.SetData(Payload{One: innerType{Secret: "(555)-555-5555"}})
 	ctx := context.Background()
-	response, _, err := client.RedactStructured(ctx, input)
+	response, err := client.RedactStructured(ctx, input)
 
 	assert.NoError(t, err)
-	assert.NotEmpty(t, response.RedactedData)
+	assert.NotEmpty(t, response.Result.RedactedData)
 
 	var got Payload
 	want := Payload{One: innerType{Secret: "<PHONE_NUMBER>"}}
-	assert.NoError(t, response.GetRedactedData(&got))
+	assert.NoError(t, response.Result.GetRedactedData(&got))
 	assert.Equal(t, want, got)
 }
 
 func TestRedactError(t *testing.T) {
 	f := func(cfg *pangea.Config) error {
 		client, _ := redact.New(cfg)
-		_, _, err := client.Redact(context.Background(), nil)
+		_, err := client.Redact(context.Background(), nil)
 		return err
 	}
 	pangeatesting.TestNewRequestAndDoFailure(t, "Redact.Redact", f)
@@ -112,7 +112,7 @@ func TestRedactError(t *testing.T) {
 func TestRedactStructuredError(t *testing.T) {
 	f := func(cfg *pangea.Config) error {
 		client, _ := redact.New(cfg)
-		_, _, err := client.RedactStructured(context.Background(), nil)
+		_, err := client.RedactStructured(context.Background(), nil)
 		return err
 	}
 	pangeatesting.TestNewRequestAndDoFailure(t, "Redact.RedactStructured", f)

--- a/service/redact/integration_test.go
+++ b/service/redact/integration_test.go
@@ -27,10 +27,10 @@ func Test_Integration_Redact(t *testing.T) {
 	input := &redact.TextInput{
 		Text: pangea.String("My Phone number is 110045638"),
 	}
-	out, _, err := client.Redact(ctx, input)
+	out, err := client.Redact(ctx, input)
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}
 
-	assert.NotNil(t, out)
+	assert.NotNil(t, out.Response)
 }

--- a/service/redact/service.go
+++ b/service/redact/service.go
@@ -7,8 +7,8 @@ import (
 )
 
 type Client interface {
-	RedactText(ctx context.Context, input *TextInput) (*TextOutput, *pangea.Response, error)
-	RedactStructured(ctx context.Context, input *StructuredInput) (*StructuredOutput, *pangea.Response, error)
+	RedactText(ctx context.Context, input *TextInput) (*pangea.PangeaResponse[TextOutput], error)
+	RedactStructured(ctx context.Context, input *StructuredInput) (*pangea.PangeaResponse[StructuredOutput], error)
 }
 
 type Redact struct {


### PR DESCRIPTION
- Define PangeaResponse as return struct of API methods.
- Fix test 
- Change examples

@ggallien13 I left some FIXME comments, please let me know what you think about them and I'll remove them and do the related work if needed.