### PR TITLE
Return parent object in Intel services

### DIFF
--- a/service/domain_intel/api.go
+++ b/service/domain_intel/api.go
@@ -12,33 +12,41 @@ import (
 //
 // Example:
 //
-//  input := &domain_intel.DomainLookupInput{
-//      	Domain: "teoghehofuuxo.su",
-//      	Raw: true,
-//      	Verbose: true,
-//      Provider: "crowdstrike",
-//  }
+//	input := &domain_intel.DomainLookupInput{
+//	    Parameters: DomainLookupParameters {
+//	    	Domain: "teoghehofuuxo.su",
+//	    	Raw: true,
+//	    	Verbose: true,
+//	    },
+//	    Provider: "crowdstrike",
+//	}
 //
-//  checkOutput, _, err := domainintel.Lookup(ctx, input)
-//
-func (e *DomainIntel) Lookup(ctx context.Context, input *DomainLookupInput) (*DomainLookupOutput, *pangea.Response, error) {
+//	checkResponse, err := domainintel.Lookup(ctx, input)
+func (e *DomainIntel) Lookup(ctx context.Context, input *DomainLookupInput) (*pangea.PangeaResponse[DomainLookupOutput], error) {
 	req, err := e.Client.NewRequest("POST", "v1/lookup", input)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	out := DomainLookupOutput{}
 	resp, err := e.Client.Do(ctx, req, &out)
-	if err != nil {
-		return nil, resp, err
+
+	if resp == nil {
+		return nil, err
 	}
-	return &out, resp, nil
+
+	panresp := pangea.PangeaResponse[DomainLookupOutput]{
+		Response: *resp,
+		Result:   &out,
+	}
+
+	return &panresp, err
 }
 
 type DomainLookupInput struct {
-	Domain  string `json:"domain"`
-	Verbose bool   `json:"verbose,omitempty"`
-	Raw     bool   `json:"raw,omitempty"`
-	Provider   string                 `json:"provider,omitempty"`
+	Domain   string `json:"domain"`
+	Verbose  bool   `json:"verbose,omitempty"`
+	Raw      bool   `json:"raw,omitempty"`
+	Provider string `json:"provider,omitempty"`
 }
 
 type LookupData struct {
@@ -48,7 +56,7 @@ type LookupData struct {
 }
 
 type DomainLookupOutput struct {
-	Data      LookupData  `json:"data"`
+	Data       LookupData  `json:"data"`
 	Parameters interface{} `json:"parameters,omitempty"`
-	RawData   interface{} `json:"raw_data,omitempty"`
+	RawData    interface{} `json:"raw_data,omitempty"`
 }

--- a/service/domain_intel/api.go
+++ b/service/domain_intel/api.go
@@ -12,16 +12,14 @@ import (
 //
 // Example:
 //
-//	input := &domain_intel.DomainLookupInput{
-//	    Parameters: DomainLookupParameters {
-//	    	Domain: "teoghehofuuxo.su",
-//	    	Raw: true,
-//	    	Verbose: true,
-//	    },
-//	    Provider: "crowdstrike",
-//	}
+//	 input := &domain_intel.DomainLookupInput{
+//	     	Domain: "teoghehofuuxo.su",
+//	     	Raw: true,
+//	     	Verbose: true,
+//	     Provider: "crowdstrike",
+//	 }
 //
-//	checkResponse, err := domainintel.Lookup(ctx, input)
+//		checkResponse, err := domainintel.Lookup(ctx, input)
 func (e *DomainIntel) Lookup(ctx context.Context, input *DomainLookupInput) (*pangea.PangeaResponse[DomainLookupOutput], error) {
 	req, err := e.Client.NewRequest("POST", "v1/lookup", input)
 	if err != nil {

--- a/service/domain_intel/integration_test.go
+++ b/service/domain_intel/integration_test.go
@@ -24,17 +24,17 @@ func Test_Integration_DomainLookup(t *testing.T) {
 	domainintel, _ := domain_intel.New(cfg)
 
 	input := &domain_intel.DomainLookupInput{
-        Domain:  "teoghehofuuxo.su",
-        Raw:     true,
-        Verbose: true,
+		Domain:   "teoghehofuuxo.su",
+		Raw:      true,
+		Verbose:  true,
 		Provider: "crowdstrike",
 	}
-	out, _, err := domainintel.Lookup(ctx, input)
+	out, err := domainintel.Lookup(ctx, input)
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}
 
 	assert.NotNil(t, out)
-	assert.NotNil(t, out.Data)
-	assert.Equal(t, out.Data.Verdict, "malicious")
+	assert.NotNil(t, out.Result.Data)
+	assert.Equal(t, out.Result.Data.Verdict, "malicious")
 }

--- a/service/domain_intel/service.go
+++ b/service/domain_intel/service.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Client interface {
-	Lookup(ctx context.Context, input *DomainLookupInput) (*DomainLookupOutput, *pangea.Response, error)
+	Lookup(ctx context.Context, input *DomainLookupInput) (*pangea.PangeaResponse[DomainLookupOutput], error)
 }
 
 type DomainIntel struct {

--- a/service/file_intel/api.go
+++ b/service/file_intel/api.go
@@ -28,7 +28,7 @@ type FileLookupInput struct {
 	HashType string `json:"hash_type"`
 	Verbose  bool   `json:"verbose,omitempty"`
 	Raw      bool   `json:"raw,omitempty"`
-	Provider   string               `json:"provider,omitempty"`
+	Provider string `json:"provider,omitempty"`
 }
 
 type LookupData struct {
@@ -38,20 +38,27 @@ type LookupData struct {
 }
 
 type FileLookupOutput struct {
-	Data      LookupData  `json:"data"`
+	Data       LookupData  `json:"data"`
 	Parameters interface{} `json:"parameters,omitempty"`
-	RawData   interface{} `json:"raw_data,omitempty"`
+	RawData    interface{} `json:"raw_data,omitempty"`
 }
 
-func (e *FileIntel) Lookup(ctx context.Context, input *FileLookupInput) (*FileLookupOutput, *pangea.Response, error) {
+func (e *FileIntel) Lookup(ctx context.Context, input *FileLookupInput) (*pangea.PangeaResponse[FileLookupOutput], error) {
 	req, err := e.Client.NewRequest("POST", "v1/lookup", input)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	out := FileLookupOutput{}
 	resp, err := e.Client.Do(ctx, req, &out)
-	if err != nil {
-		return nil, resp, err
+
+	if resp == nil {
+		return nil, err
 	}
-	return &out, resp, nil
+
+	panresp := pangea.PangeaResponse[FileLookupOutput]{
+		Response: *resp,
+		Result:   &out,
+	}
+
+	return &panresp, err
 }

--- a/service/file_intel/integration_test.go
+++ b/service/file_intel/integration_test.go
@@ -24,18 +24,19 @@ func Test_Integration_FileLookup(t *testing.T) {
 	fileintel, _ := file_intel.New(cfg)
 
 	input := &file_intel.FileLookupInput{
-        Hash:     "142b638c6a60b60c7f9928da4fb85a5a8e1422a9ffdc9ee49e17e56ccca9cf6e",
-        HashType: "sha256",
-        Raw:      true,
-        Verbose:  true,
+		Hash:     "142b638c6a60b60c7f9928da4fb85a5a8e1422a9ffdc9ee49e17e56ccca9cf6e",
+		HashType: "sha256",
+		Raw:      true,
+		Verbose:  true,
 		Provider: "reversinglabs",
 	}
-	out, _, err := fileintel.Lookup(ctx, input)
+	out, err := fileintel.Lookup(ctx, input)
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}
 
 	assert.NotNil(t, out)
-	assert.NotNil(t, out.Data)
-	assert.Equal(t, "malicious", out.Data.Verdict)
+	assert.NotNil(t, out.Result)
+	assert.NotNil(t, out.Result.Data)
+	assert.Equal(t, "malicious", out.Result.Data.Verdict)
 }

--- a/service/file_intel/service.go
+++ b/service/file_intel/service.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Client interface {
-	Lookup(ctx context.Context, input *FileLookupInput) (*FileLookupOutput, *pangea.Response, error)
+	Lookup(ctx context.Context, input *FileLookupInput) (*pangea.PangeaResponse[FileLookupOutput], error)
 }
 
 type FileIntel struct {

--- a/service/ip_intel/api.go
+++ b/service/ip_intel/api.go
@@ -12,33 +12,41 @@ import (
 //
 // Example:
 //
-//  input := &ip_intel.IpLookupInput{
-//      Ip: "93.231.182.110",
-//      Raw: true,
-//      Verbose: true,
-//      Provider: "crowdstrike",
-//  }
+//	input := &ip_intel.IpLookupInput{
+//	    Parameters: IpLookupParameters {
+//	    	Ip: "93.231.182.110",
+//	    	Raw: true,
+//	    	Verbose: true,
+//	    },
+//	    Provider: "crowdstrike",
+//	}
 //
-//  checkOutput, _, err := ipintel.Lookup(ctx, input)
-//
-func (e *IpIntel) Lookup(ctx context.Context, input *IpLookupInput) (*IpLookupOutput, *pangea.Response, error) {
+//	checkOutput, _, err := ipintel.Lookup(ctx, input)
+func (e *IpIntel) Lookup(ctx context.Context, input *IpLookupInput) (*pangea.PangeaResponse[IpLookupOutput], error) {
 	req, err := e.Client.NewRequest("POST", "v1/lookup", input)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	out := IpLookupOutput{}
 	resp, err := e.Client.Do(ctx, req, &out)
-	if err != nil {
-		return nil, resp, err
+
+	if resp == nil {
+		return nil, err
 	}
-	return &out, resp, nil
+
+	panresp := pangea.PangeaResponse[IpLookupOutput]{
+		Response: *resp,
+		Result:   &out,
+	}
+
+	return &panresp, err
 }
 
 type IpLookupInput struct {
-	Ip      string `json:"ip"`
-	Verbose bool   `json:"verbose,omitempty"`
-	Raw     bool   `json:"raw,omitempty"`
-	Provider   string             `json:"provider,omitempty"`
+	Ip       string `json:"ip"`
+	Verbose  bool   `json:"verbose,omitempty"`
+	Raw      bool   `json:"raw,omitempty"`
+	Provider string `json:"provider,omitempty"`
 }
 
 type LookupData struct {
@@ -48,7 +56,7 @@ type LookupData struct {
 }
 
 type IpLookupOutput struct {
-	Data      LookupData  `json:"data"`
+	Data       LookupData  `json:"data"`
 	Parameters interface{} `json:"parameters,omitempty"`
-	RawData   interface{} `json:"raw_data,omitempty"`
+	RawData    interface{} `json:"raw_data,omitempty"`
 }

--- a/service/ip_intel/api.go
+++ b/service/ip_intel/api.go
@@ -12,16 +12,14 @@ import (
 //
 // Example:
 //
-//	input := &ip_intel.IpLookupInput{
-//	    Parameters: IpLookupParameters {
-//	    	Ip: "93.231.182.110",
-//	    	Raw: true,
-//	    	Verbose: true,
-//	    },
-//	    Provider: "crowdstrike",
-//	}
+//	 input := &ip_intel.IpLookupInput{
+//	     Ip: "93.231.182.110",
+//	     Raw: true,
+//	     Verbose: true,
+//	     Provider: "crowdstrike",
+//	 }
 //
-//	checkOutput, _, err := ipintel.Lookup(ctx, input)
+//		checkOutput, _, err := ipintel.Lookup(ctx, input)
 func (e *IpIntel) Lookup(ctx context.Context, input *IpLookupInput) (*pangea.PangeaResponse[IpLookupOutput], error) {
 	req, err := e.Client.NewRequest("POST", "v1/lookup", input)
 	if err != nil {

--- a/service/ip_intel/integration_test.go
+++ b/service/ip_intel/integration_test.go
@@ -24,17 +24,18 @@ func Test_Integration_IpLookup(t *testing.T) {
 	ipintel, _ := ip_intel.New(cfg)
 
 	input := &ip_intel.IpLookupInput{
-        Ip:      "93.231.182.110",
-        Raw:     true,
-        Verbose: true,
+		Ip:       "93.231.182.110",
+		Raw:      true,
+		Verbose:  true,
 		Provider: "crowdstrike",
 	}
-	out, _, err := ipintel.Lookup(ctx, input)
+	out, err := ipintel.Lookup(ctx, input)
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}
 
 	assert.NotNil(t, out)
-	assert.NotNil(t, out.Data)
-	assert.Equal(t, out.Data.Verdict, "malicious")
+	assert.NotNil(t, out.Result)
+	assert.NotNil(t, out.Result.Data)
+	assert.Equal(t, out.Result.Data.Verdict, "malicious")
 }

--- a/service/ip_intel/service.go
+++ b/service/ip_intel/service.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Client interface {
-	Lookup(ctx context.Context, input *IpLookupInput) (*IpLookupOutput, *pangea.Response, error)
+	Lookup(ctx context.Context, input *IpLookupInput) (*pangea.PangeaResponse[IpLookupOutput], error)
 }
 
 type IpIntel struct {

--- a/service/url_intel/api.go
+++ b/service/url_intel/api.go
@@ -12,16 +12,14 @@ import (
 //
 // Example:
 //
-//	input := &url_intel.UrlLookupInput{
-//	    Parameters: UrlLookupParameters {
-//	    	Url: "http://113.235.101.11:54384",
-//	    	Raw: true,
-//	    	Verbose: true,
-//	    },
-//	    Provider: "crowdstrike",
-//	}
+//	 input := &url_intel.UrlLookupInput{
+//	     Url: "http://113.235.101.11:54384",
+//	     Raw: true,
+//	     Verbose: true,
+//	     Provider: "crowdstrike",
+//	 }
 //
-//	checkOutput, _, err := urlintel.Lookup(ctx, input)
+//		checkOutput, _, err := urlintel.Lookup(ctx, input)
 func (e *UrlIntel) Lookup(ctx context.Context, input *UrlLookupInput) (*pangea.PangeaResponse[UrlLookupOutput], error) {
 	req, err := e.Client.NewRequest("POST", "v1/lookup", input)
 	if err != nil {

--- a/service/url_intel/api.go
+++ b/service/url_intel/api.go
@@ -12,33 +12,41 @@ import (
 //
 // Example:
 //
-//  input := &url_intel.UrlLookupInput{
-//      Url: "http://113.235.101.11:54384",
-//      Raw: true,
-//      Verbose: true,
-//      Provider: "crowdstrike",
-//  }
+//	input := &url_intel.UrlLookupInput{
+//	    Parameters: UrlLookupParameters {
+//	    	Url: "http://113.235.101.11:54384",
+//	    	Raw: true,
+//	    	Verbose: true,
+//	    },
+//	    Provider: "crowdstrike",
+//	}
 //
-//  checkOutput, _, err := urlintel.Lookup(ctx, input)
-//
-func (e *UrlIntel) Lookup(ctx context.Context, input *UrlLookupInput) (*UrlLookupOutput, *pangea.Response, error) {
+//	checkOutput, _, err := urlintel.Lookup(ctx, input)
+func (e *UrlIntel) Lookup(ctx context.Context, input *UrlLookupInput) (*pangea.PangeaResponse[UrlLookupOutput], error) {
 	req, err := e.Client.NewRequest("POST", "v1/lookup", input)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	out := UrlLookupOutput{}
 	resp, err := e.Client.Do(ctx, req, &out)
-	if err != nil {
-		return nil, resp, err
+
+	if resp == nil {
+		return nil, err
 	}
-	return &out, resp, nil
+
+	panresp := pangea.PangeaResponse[UrlLookupOutput]{
+		Response: *resp,
+		Result:   &out,
+	}
+
+	return &panresp, err
 }
 
 type UrlLookupInput struct {
-	Url     string `json:"url"`
-	Verbose bool   `json:"verbose,omitempty"`
-	Raw     bool   `json:"raw,omitempty"`
-	Provider   string              `json:"provider,omitempty"`
+	Url      string `json:"url"`
+	Verbose  bool   `json:"verbose,omitempty"`
+	Raw      bool   `json:"raw,omitempty"`
+	Provider string `json:"provider,omitempty"`
 }
 
 type LookupData struct {
@@ -48,7 +56,7 @@ type LookupData struct {
 }
 
 type UrlLookupOutput struct {
-	Data      LookupData  `json:"data"`
+	Data       LookupData  `json:"data"`
 	Parameters interface{} `json:"parameters,omitempty"`
-	RawData   interface{} `json:"raw_data,omitempty"`
+	RawData    interface{} `json:"raw_data,omitempty"`
 }

--- a/service/url_intel/integration_test.go
+++ b/service/url_intel/integration_test.go
@@ -24,17 +24,18 @@ func Test_Integration_UrlLookup(t *testing.T) {
 	urlintel, _ := url_intel.New(cfg)
 
 	input := &url_intel.UrlLookupInput{
-        Url:     "http://113.235.101.11:54384",
-        Raw:     true,
-        Verbose: true,
+		Url:      "http://113.235.101.11:54384",
+		Raw:      true,
+		Verbose:  true,
 		Provider: "crowdstrike",
 	}
-	out, _, err := urlintel.Lookup(ctx, input)
+	out, err := urlintel.Lookup(ctx, input)
 	if err != nil {
 		t.Fatalf("expected no error got: %v", err)
 	}
 
 	assert.NotNil(t, out)
-	assert.NotNil(t, out.Data)
-	assert.Equal(t, out.Data.Verdict, "malicious")
+	assert.NotNil(t, out.Result)
+	assert.NotNil(t, out.Result.Data)
+	assert.Equal(t, out.Result.Data.Verdict, "malicious")
 }

--- a/service/url_intel/service.go
+++ b/service/url_intel/service.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Client interface {
-	Lookup(ctx context.Context, input *UrlLookupInput) (*UrlLookupOutput, *pangea.Response, error)
+	Lookup(ctx context.Context, input *UrlLookupInput) (*pangea.PangeaResponse[UrlLookupOutput], error)
 }
 
 type UrlIntel struct {


### PR DESCRIPTION
- Return parent object from request to make it consistent with Audit Log and Search, Embargo and Redact.
- Fix test to make it work with parent object
- Fix some tabulations and spaces