### PR TITLE
Update response payload structure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,13 @@ go 1.18
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/stretchr/testify v1.8.0
+	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
 	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 h1:Y/gsMcFOcR+6S6f3YeMKl5
 golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pangea/pangea.go
+++ b/pangea/pangea.go
@@ -254,7 +254,8 @@ func CheckResponse(r *Response) error {
 	if r.HTTPResponse.StatusCode == http.StatusAccepted {
 		return &AcceptedError{ResponseHeader: r.ResponseHeader}
 	}
-	if r.HTTPResponse.StatusCode <= http.StatusOK {
+
+	if r.HTTPResponse.StatusCode == http.StatusOK && *r.ResponseHeader.Status == "Success" {
 		return nil
 	}
 	return &APIError{

--- a/pangea/pangea_test.go
+++ b/pangea/pangea_test.go
@@ -117,6 +117,7 @@ func TestDo_When_Server_Returns_200_It_UnMarshals_Result_Into_Struct(t *testing.
 	}
 
 	assert.NotNil(t, resp)
+	assert.NotNil(t, resp.Status)
 	assert.NotNil(t, *resp.Status)
 	assert.Equal(t, "Success", *resp.Status)
 

--- a/pangea/pangea_test.go
+++ b/pangea/pangea_test.go
@@ -118,7 +118,6 @@ func TestDo_When_Server_Returns_200_It_UnMarshals_Result_Into_Struct(t *testing.
 
 	assert.NotNil(t, resp)
 	assert.NotNil(t, resp.Status)
-	assert.NotNil(t, *resp.Status)
 	assert.Equal(t, "Success", *resp.Status)
 
 	assert.NotNil(t, body.Key)

--- a/pangea/pangea_test.go
+++ b/pangea/pangea_test.go
@@ -28,13 +28,8 @@ func TestDo_When_Nil_Context_Is_Given_It_Returns_Error(t *testing.T) {
 	req, _ := client.NewRequest("GET", ".", nil)
 	_, err := client.Do(nil, req, nil)
 
-	if err == nil {
-		t.Errorf("Expected error")
-	}
-
-	if err.Error() != "context must be non-nil" {
-		t.Errorf("Expected error message to be 'context must be non-nil', got %s", err.Error())
-	}
+	assert.Error(t, err)
+	assert.Equal(t, "context must be non-nil", err.Error())
 }
 
 func TestDo_When_Server_Returns_400_It_Returns_Error(t *testing.T) {
@@ -44,14 +39,13 @@ func TestDo_When_Server_Returns_400_It_Returns_Error(t *testing.T) {
 	client := testClient(t, url)
 
 	mux.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, `{
 			"request_id": "some-id",
 			"request_time": "1970-01-01T00:00:00Z",
 			"response_time": "1970-01-01T00:00:10Z",
-			"status_code": 400,
-			"status": "error",
-			"result": null,
+			"status": "ValidationError",
+			"result": {"errors": []},
 			"summary": "bad request"
 		}`)
 	})
@@ -59,23 +53,12 @@ func TestDo_When_Server_Returns_400_It_Returns_Error(t *testing.T) {
 	req, _ := client.NewRequest("POST", "test", nil)
 	_, err := client.Do(context.Background(), req, nil)
 
-	if err == nil {
-		t.Fatal("Expected HTTP 400 error, got no error.")
-	}
+	assert.Error(t, err)
 
 	pangeaErr, ok := err.(*pangea.APIError)
-	if !ok {
-		t.Fatalf("Expected pangea.APIError, got %T", err)
-	}
-	if pangeaErr.ResponseHeader == nil {
-		t.Fatal("Expected ResponseMetadata to be non-nil")
-	}
-	if pangeaErr.ResponseHeader.StatusCode == nil {
-		t.Fatal("Expected non-nil status code")
-	}
-	if *pangeaErr.ResponseHeader.StatusCode != http.StatusBadRequest {
-		t.Errorf("Expected status code %d, got %d", http.StatusBadRequest, *pangeaErr.ResponseHeader.StatusCode)
-	}
+	assert.True(t, ok)
+	assert.NotNil(t, pangeaErr.ResponseHeader)
+	assert.Equal(t, "ValidationError", *pangeaErr.ResponseHeader.Status)
 }
 
 func TestDo_When_Server_Returns_500_It_Returns_Error(t *testing.T) {
@@ -90,8 +73,7 @@ func TestDo_When_Server_Returns_500_It_Returns_Error(t *testing.T) {
 			"request_id": "some-id",
 			"request_time": "1970-01-01T00:00:00Z",
 			"response_time": "1970-01-01T00:00:10Z",
-			"status_code": 500,
-			"status": "error",
+			"status": "InternalError",
 			"result": null,
 			"summary": "error"
 		}`)
@@ -99,24 +81,12 @@ func TestDo_When_Server_Returns_500_It_Returns_Error(t *testing.T) {
 
 	req, _ := client.NewRequest("POST", "test", nil)
 	_, err := client.Do(context.Background(), req, nil)
-
-	if err == nil {
-		t.Fatal("Expected HTTP 500 error, got no error.")
-	}
-
+	assert.Error(t, err)
 	pangeaErr, ok := err.(*pangea.APIError)
-	if !ok {
-		t.Fatalf("Expected pangea.APIError, got %v", err)
-	}
-	if pangeaErr.ResponseHeader == nil {
-		t.Fatal("Expected ResponseMetadata to be non-nil")
-	}
-	if pangeaErr.ResponseHeader.StatusCode == nil {
-		t.Fatal("Expected non-nil status code")
-	}
-	if *pangeaErr.ResponseHeader.StatusCode != http.StatusInternalServerError {
-		t.Errorf("Expected status code %d, got %d", http.StatusInternalServerError, *pangeaErr.ResponseHeader.StatusCode)
-	}
+	assert.True(t, ok)
+	assert.NotNil(t, pangeaErr.ResponseHeader)
+	assert.NotNil(t, pangeaErr.ResponseHeader.Status)
+	assert.Equal(t, "InternalError", *pangeaErr.ResponseHeader.Status)
 }
 
 func TestDo_When_Server_Returns_200_It_UnMarshals_Result_Into_Struct(t *testing.T) {
@@ -131,8 +101,7 @@ func TestDo_When_Server_Returns_200_It_UnMarshals_Result_Into_Struct(t *testing.
 			"request_id": "some-id",
 			"request_time": "1970-01-01T00:00:00Z",
 			"response_time": "1970-01-01T00:00:10Z",
-			"status_code": 200,
-			"status": "ok",
+			"status": "Success",
 			"result": {"key": "value"},
 			"summary": "ok"
 		}`)
@@ -147,21 +116,12 @@ func TestDo_When_Server_Returns_200_It_UnMarshals_Result_Into_Struct(t *testing.
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
-	if resp == nil {
-		t.Fatal("Expected non-nil response")
-	}
+	assert.NotNil(t, resp)
+	assert.NotNil(t, *resp.Status)
+	assert.Equal(t, "Success", *resp.Status)
 
-	if resp.StatusCode == nil || *resp.StatusCode != http.StatusOK {
-		t.Fatal("Expected status code 200")
-	}
-
-	if body.Key == nil {
-		t.Fatal("Expected body.Key to be non-nil")
-	}
-
-	if *body.Key != "value" {
-		t.Errorf("Expected body.Key to be 'value', got %v", *body.Key)
-	}
+	assert.NotNil(t, body.Key)
+	assert.Equal(t, "value", *body.Key)
 }
 
 func TestDo_Request_With_Body_Sends_Request_With_Json_Body(t *testing.T) {
@@ -190,25 +150,17 @@ func TestDo_Request_With_Body_Sends_Request_With_Json_Body(t *testing.T) {
 			"request_id": "some-id",
 			"request_time": "1970-01-01T00:00:00Z",
 			"response_time": "1970-01-01T00:00:10Z",
-			"status_code": 200,
-			"status": "ok",
+			"status": "Success",
 			"result": null,
 			"summary": "ok"
 		}`)
 	})
 
 	resp, err := client.Do(context.Background(), req, nil)
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-
-	if resp == nil {
-		t.Fatal("Expected non-nil response")
-	}
-
-	if resp.StatusCode == nil || *resp.StatusCode != http.StatusOK {
-		t.Error("Expected status code 200")
-	}
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.NotNil(t, resp.Status)
+	assert.Equal(t, *resp.Status, "Success")
 }
 
 func TestDo_When_Client_Can_Not_UnMarshall_Response_It_Returns_UnMarshalError(t *testing.T) {
@@ -226,14 +178,8 @@ func TestDo_When_Client_Can_Not_UnMarshall_Response_It_Returns_UnMarshalError(t 
 
 	_, err := client.Do(context.Background(), req, nil)
 
-	if err == nil {
-		t.Fatal("Expected an error")
-	}
-
-	_, ok := err.(*pangea.UnMarshalError)
-	if !ok {
-		t.Errorf("Expected pangea.UnMarshalError, got %T", err)
-	}
+	var v *pangea.UnMarshalError
+	assert.ErrorAs(t, err, &v)
 }
 
 func TestDo_When_Client_Can_Not_UnMarshall_Response_Result_Into_Body_It_Returns_UnMarshalError(t *testing.T) {
@@ -250,8 +196,7 @@ func TestDo_When_Client_Can_Not_UnMarshall_Response_Result_Into_Body_It_Returns_
 			"request_id": "some-id",
 			"request_time": "1970-01-01T00:00:00Z",
 			"response_time": "1970-01-01T00:00:10Z",
-			"status_code": 200,
-			"status": "ok",
+			"status": "Success",
 			"summary": "ok"
 		}`)
 	})
@@ -261,14 +206,8 @@ func TestDo_When_Client_Can_Not_UnMarshall_Response_Result_Into_Body_It_Returns_
 	}{}
 	_, err := client.Do(context.Background(), req, body)
 
-	if err == nil {
-		t.Fatal("Expected an error")
-	}
-
-	_, ok := err.(*pangea.UnMarshalError)
-	if !ok {
-		t.Errorf("Expected pangea.UnMarshalError, got %T", err)
-	}
+	var v *pangea.UnMarshalError
+	assert.ErrorAs(t, err, &v)
 }
 
 func TestDo_With_Retries_Success(t *testing.T) {
@@ -292,8 +231,7 @@ func TestDo_With_Retries_Success(t *testing.T) {
 					"request_id": "some-id",
 					"request_time": "1970-01-01T00:00:00Z",
 					"response_time": "1970-01-01T00:00:10Z",
-					"status_code": 200,
-					"status": "ok",
+					"status": "Success",
 					"summary": "ok"
 				}`)
 			} else {
@@ -306,17 +244,10 @@ func TestDo_With_Retries_Success(t *testing.T) {
 
 	resp, err := client.Do(context.Background(), req, nil)
 
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-
-	if resp == nil {
-		t.Fatal("Expected non-nil response")
-	}
-
-	if resp.StatusCode == nil || *resp.StatusCode != http.StatusOK {
-		t.Error("Expected status code 200")
-	}
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.NotNil(t, resp.Status)
+	assert.Equal(t, "Success", *resp.Status)
 }
 
 func TestDo_With_Retries_Error(t *testing.T) {
@@ -338,14 +269,8 @@ func TestDo_With_Retries_Error(t *testing.T) {
 
 	_, err := client.Do(context.Background(), req, nil)
 
-	if err == nil {
-		t.Fatal("Expected HTTP 500 error, got no error.")
-	}
-
-	_, ok := err.(*pangea.APIError)
-	if !ok {
-		t.Fatalf("Expected pangea.APIError, got %T", err)
-	}
+	var v *pangea.APIError
+	assert.ErrorAs(t, err, &v)
 }
 
 func TestDo_When_Server_Returns_202_It_Returns_AcceptedError(t *testing.T) {
@@ -360,8 +285,7 @@ func TestDo_When_Server_Returns_202_It_Returns_AcceptedError(t *testing.T) {
 			"request_id": "some-id",
 			"request_time": "1970-01-01T00:00:00Z",
 			"response_time": "1970-01-01T00:00:10Z",
-			"status_code": 202,
-			"status": "error",
+			"status": "Accepted",
 			"result": null,
 			"summary": "Accepted"
 		}`)
@@ -374,54 +298,8 @@ func TestDo_When_Server_Returns_202_It_Returns_AcceptedError(t *testing.T) {
 		t.Fatal("Expected error")
 	}
 
-	pangeaErr, ok := err.(*pangea.AcceptedError)
-	if !ok {
-		t.Fatalf("Expected pangea.AcceptedError, got %T", err)
-	}
-	if pangeaErr.ResponseHeader.StatusCode == nil {
-		t.Fatal("Expected non-nil status code")
-	}
-	if *pangeaErr.ResponseHeader.StatusCode != http.StatusAccepted {
-		t.Errorf("Expected status code %d, got %d", http.StatusAccepted, *pangeaErr.ResponseHeader.StatusCode)
-	}
-}
-
-func TestFetchAcceptedResponse_When_Server_Returns_200_It_JSON_Marshals_Payload(t *testing.T) {
-	mux, url, teardown := pangeatesting.SetupServer()
-	defer teardown()
-
-	client := testClient(t, url)
-
-	mux.HandleFunc("/request/id", func(w http.ResponseWriter, r *http.Request) {
-		pangeatesting.TestMethod(t, r, "GET")
-		pangeatesting.TestBody(t, r, "")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{
-			"request_id": "some-id",
-			"request_time": "1970-01-01T00:00:00Z",
-			"response_time": "1970-01-01T00:00:10Z",
-			"status_code": 200,
-			"status": "error",
-			"result": {
-				"key": "value"
-			},
-			"summary": "Accepted"
-		}`)
-	})
-
-	type Payload struct {
-		Key *string `json:"key"`
-	}
-
-	var payload *Payload
-	_, err := client.FetchAcceptedResponse(context.Background(), "id", &payload)
-
-	if err != nil {
-		t.Fatalf("Expected no error got %v", err)
-	}
-
-	assert.NoError(t, err)
-	assert.NotNil(t, payload)
-	assert.NotNil(t, payload.Key)
-	assert.Equal(t, "value", *payload.Key)
+	var v *pangea.AcceptedError
+	assert.ErrorAs(t, err, &v)
+	assert.NotNil(t, v.ResponseHeader.Status)
+	assert.Equal(t, "Accepted", *v.ResponseHeader.Status)
 }

--- a/pangea/response.go
+++ b/pangea/response.go
@@ -19,9 +19,6 @@ type ResponseHeader struct {
 	// The HTTP status code msg
 	Status *string `json:"status"`
 
-	// The HTTP status code
-	StatusCode *int `json:"status_code"`
-
 	// The summary of the response
 	Summary *string `json:"summary"`
 }
@@ -37,7 +34,7 @@ func (r *ResponseHeader) String() string {
 	if r == nil {
 		return ""
 	}
-	return fmt.Sprintf("request_id: %v, request_time: %v, response_time: %v, status_code: %v, status: %v, summary: %v",
-		StringValue(r.RequestID), StringValue(r.RequestTime), StringValue(r.ResponseTime), IntValue(r.StatusCode),
+	return fmt.Sprintf("request_id: %v, request_time: %v, response_time: %v, status: %v, summary: %v",
+		StringValue(r.RequestID), StringValue(r.RequestTime), StringValue(r.ResponseTime),
 		StringValue(r.Status), StringValue(r.Summary))
 }

--- a/pangea/response_test.go
+++ b/pangea/response_test.go
@@ -10,7 +10,6 @@ func TestResponseHeader_String(t *testing.T) {
 	want := "request_id: some-id, " +
 		"request_time: 1970-01-01T00:00:00Z, " +
 		"response_time: 1970-01-01T00:00:10Z, " +
-		"status_code: 418, " +
 		"status: I'm a teapot, " +
 		"summary: I'm a teapot"
 
@@ -18,7 +17,6 @@ func TestResponseHeader_String(t *testing.T) {
 		RequestID:    pangea.String("some-id"),
 		RequestTime:  pangea.String("1970-01-01T00:00:00Z"),
 		ResponseTime: pangea.String("1970-01-01T00:00:10Z"),
-		StatusCode:   pangea.Int(418),
 		Status:       pangea.String("I'm a teapot"),
 		Summary:      pangea.String("I'm a teapot"),
 	}

--- a/service/audit/api_test.go
+++ b/service/audit/api_test.go
@@ -25,8 +25,7 @@ func TestLog(t *testing.T) {
 				"request_id": "some-id",
 				"request_time": "1970-01-01T00:00:00Z",
 				"response_time": "1970-01-01T00:00:10Z",
-				"status_code": 200,
-				"status": "success",
+				"status": "Success",
 				"result": {
 					"canonical_envelope_base64": "eyJtZXNzYWdlIjoicHJ1ZWJhXzQ1NiIsInJlY2VpdmVkX2F0IjoiMjAyMi0wNi0yOFQfadDowMjowNS40ODAyNjdaIn0=",
 					"envelope": {
@@ -77,8 +76,7 @@ func TestDomainTrailingSlash(t *testing.T) {
 				"request_id": "some-id",
 				"request_time": "1970-01-01T00:00:00Z",
 				"response_time": "1970-01-01T00:00:10Z",
-				"status_code": 200,
-				"status": "success",
+				"status": "Success",
 				"result": {
 					"canonical_envelope_base64": "eyJtZXNzYWdlIjoicHJ1ZWJhXzQ1NiIsInJlY2VpdmVkX2F0IjoiMjAyMi0wNi0yOFQfadDowMjowNS40ODAyNjdaIn0=",
 					"envelope": {
@@ -132,8 +130,7 @@ func TestSearch(t *testing.T) {
 				"request_id": "some-id",
 				"request_time": "1970-01-01T00:00:00Z",
 				"response_time": "1970-01-01T00:00:10Z",
-				"status_code": 200,
-				"status": "success",
+				"status": "Success",
 				"result": {
 					"count": 2,
 					"events": [
@@ -218,8 +215,7 @@ func TestSearchResults(t *testing.T) {
 				"request_id": "some-id",
 				"request_time": "1970-01-01T00:00:00Z",
 				"response_time": "1970-01-01T00:00:10Z",
-				"status_code": 200,
-				"status": "success",
+				"status": "Success",
 				"result": {
 					"count": 2,
 					"events": [
@@ -319,8 +315,7 @@ func TestRoot(t *testing.T) {
 				"request_id": "some-id",
 				"request_time": "1970-01-01T00:00:00Z",
 				"response_time": "1970-01-01T00:00:10Z",
-				"status_code": 200,
-				"status": "success",
+				"status": "Success",
 				"result": {
 					"data":  {
 						"published_at": "%v",

--- a/service/embargo/api_test.go
+++ b/service/embargo/api_test.go
@@ -24,8 +24,7 @@ func TestISOCheck(t *testing.T) {
 				"request_id": "some-id",
 				"request_time": "1970-01-01T00:00:00Z",
 				"response_time": "1970-01-01T00:00:10Z",
-				"status_code": 200,
-				"status": "success",
+				"status": "Success",
 				"result":{
 					"sanctions": [
 						{
@@ -89,8 +88,7 @@ func TestIPCheck(t *testing.T) {
 				"request_id": "some-id",
 				"request_time": "1970-01-01T00:00:00Z",
 				"response_time": "1970-01-01T00:00:10Z",
-				"status_code": 200,
-				"status": "success",
+				"status": "Success",
 				"result":{
 					"sanctions": [
 						{

--- a/service/redact/api_test.go
+++ b/service/redact/api_test.go
@@ -24,8 +24,7 @@ func TestRedact(t *testing.T) {
 				"request_id": "some-id",
 				"request_time": "1970-01-01T00:00:00Z",
 				"response_time": "1970-01-01T00:00:10Z",
-				"status_code": 200,
-				"status": "success",
+				"status": "Success",
 				"result":{
 					"redacted_text": "My phone number is: <PHONE_NUMBER>"
 				},
@@ -60,8 +59,7 @@ func TestRedactStructured(t *testing.T) {
 				"request_id": "some-id",
 				"request_time": "1970-01-01T00:00:00Z",
 				"response_time": "1970-01-01T00:00:10Z",
-				"status_code": 200,
-				"status": "success",
+				"status": "Success",
 				"result": {
 					"redacted_data": {
 					  "one": { "secret": "<PHONE_NUMBER>" }


### PR DESCRIPTION
Pangea has removed `status_code` from their response payloads in favor of a custom `status` field which is an enum defined in their API docs.