### PR TITLE
Remove deprecated parameters

### DIFF
--- a/service/audit/api.go
+++ b/service/audit/api.go
@@ -173,9 +173,7 @@ func SearchAll(ctx context.Context, client Client, input *SearchInput) (*Root, S
 	events = append(events, resp.Result.Events...)
 	for resp.Result.Count > len(events) {
 		s := SearchResultInput{
-			ID:                     resp.Result.ID,
-			IncludeMembershipProof: input.IncludeMembershipProof,
-			IncludeHash:            input.IncludeHash,
+			ID: resp.Result.ID,
 		}
 		sOut, err := client.SearchResults(ctx, &s)
 		if err != nil {
@@ -355,9 +353,6 @@ type SearchInput struct {
 	// Name of column to sort the results by.
 	OrderBy string `json:"order_by,omitempty"`
 
-	// If set, the last value from the response to fetch the next page from.
-	Last string `json:"last,omitempty"`
-
 	// The start of the time range to perform the search on.
 	Start *time.Time `json:"start,omitempty"`
 
@@ -501,15 +496,6 @@ type SearchResultInput struct {
 	// A search results identifier returned by the search call
 	// ID is a required field
 	ID string `json:"id"`
-
-	// If true, include membership proofs for each record in the first page.
-	IncludeMembershipProof bool `json:"include_membership_proof,omitempty"`
-
-	// If true, include hashes for each record in the first page.
-	IncludeHash bool `json:"include_hash,omitempty"`
-
-	// If true, include the Merkle root hash of the tree in the first page.
-	IncludeRoot bool `json:"include_root,omitempty"`
 
 	// Number of audit records to include from the first page of the results.
 	Limit int `json:"limit,omitempty"`

--- a/service/audit/api_test.go
+++ b/service/audit/api_test.go
@@ -694,7 +694,7 @@ func TestSearchResults(t *testing.T) {
 	t1 := time.Date(2018, time.September, 16, 12, 0, 0, 0, time.FixedZone("", 2*60*60))
 	mux.HandleFunc("/v1/results", func(w http.ResponseWriter, r *http.Request) {
 		pangeatesting.TestMethod(t, r, "POST")
-		pangeatesting.TestBody(t, r, `{"id":"some-id","include_membership_proof":true,"limit":50}`)
+		pangeatesting.TestBody(t, r, `{"id":"some-id","limit":50}`)
 		fmt.Fprintf(w,
 			`{
 				"request_id": "some-id",
@@ -741,9 +741,8 @@ func TestSearchResults(t *testing.T) {
 
 	client, _ := audit.New(pangeatesting.TestConfig(url))
 	input := &audit.SearchResultInput{
-		ID:                     "some-id",
-		IncludeMembershipProof: true,
-		Limit:                  50,
+		ID:    "some-id",
+		Limit: 50,
 	}
 	ctx := context.Background()
 	got, err := client.SearchResults(ctx, input)


### PR DESCRIPTION
Remove return_hash, return_root and return_membership_proof from results endpoint. They are selected when search was done 